### PR TITLE
Refactor codebase for improved structure and maintainability

### DIFF
--- a/cmd/config_adapter.go
+++ b/cmd/config_adapter.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/ncode/ballot/internal/ballot"
+	"github.com/spf13/viper"
+)
+
+func runtimeConfigFromViper(name string) (ballot.RuntimeConfig, error) {
+	serviceKey := "election.services." + name + "."
+	config := ballot.LoadedConfig{
+		Consul: ballot.LoadedConsulConfig{
+			Address: viper.GetString("consul.address"),
+			Token:   viper.GetString("consul.token"),
+		},
+		Election: ballot.LoadedElectionConfig{
+			Services: map[string]ballot.LoadedServiceConfig{
+				name: {
+					Name:          viper.GetString(serviceKey + "name"),
+					ID:            viper.GetString(serviceKey + "id"),
+					Key:           viper.GetString(serviceKey + "key"),
+					ServiceChecks: viper.GetStringSlice(serviceKey + "serviceChecks"),
+					Token:         viper.GetString(serviceKey + "token"),
+					ExecOnPromote: viper.GetString(serviceKey + "execOnPromote"),
+					ExecOnDemote:  viper.GetString(serviceKey + "execOnDemote"),
+					PrimaryTag:    viper.GetString(serviceKey + "primaryTag"),
+					TTL:           viper.GetString(serviceKey + "ttl"),
+					LockDelay:     viper.GetString(serviceKey + "lockDelay"),
+				},
+			},
+		},
+	}
+	return ballot.RuntimeConfigFor(config, name)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,11 @@ func runElectionWithContext(ctx context.Context) error {
 	errCh := make(chan error, len(enabledServices))
 
 	for _, name := range enabledServices {
-		b, err := ballot.New(ctx, name)
+		cfg, err := runtimeConfigFromViper(name)
+		if err != nil {
+			return fmt.Errorf("failed to load configuration for service %s: %w", name, err)
+		}
+		b, err := ballot.New(ctx, cfg)
 		if err != nil {
 			return fmt.Errorf("failed to create ballot for service %s: %w", name, err)
 		}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -44,13 +44,38 @@ func TestRunElectionWithContext_InvalidService(t *testing.T) {
 
 	err := runElectionWithContext(ctx)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create ballot for service invalid_service")
+	assert.Contains(t, err.Error(), "failed to load configuration for service invalid_service")
 }
 
 func TestRunCmd_Structure(t *testing.T) {
 	assert.Equal(t, "run", runCmd.Use)
 	assert.NotEmpty(t, runCmd.Short)
 	assert.NotNil(t, runCmd.RunE)
+}
+
+func TestRuntimeConfigFromViper(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	viper.Set("consul.address", "127.0.0.1:8500")
+	viper.Set("consul.token", "global-token")
+	viper.Set("election.services.test_service.id", "test_id")
+	viper.Set("election.services.test_service.key", "election/test/leader")
+	viper.Set("election.services.test_service.primaryTag", "primary")
+	viper.Set("election.services.test_service.serviceChecks", []string{"service:test_id"})
+	viper.Set("election.services.test_service.execOnPromote", "echo promoted")
+	viper.Set("election.services.test_service.execOnDemote", "echo demoted")
+	viper.Set("election.services.test_service.ttl", "12s")
+	viper.Set("election.services.test_service.lockDelay", "4s")
+
+	cfg, err := runtimeConfigFromViper("test_service")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test_service", cfg.Name)
+	assert.Equal(t, "test_id", cfg.ID)
+	assert.Equal(t, "election/test/leader", cfg.Key)
+	assert.Equal(t, "127.0.0.1:8500", cfg.ConsulAddress)
+	assert.Equal(t, "global-token", cfg.ConsulToken)
 }
 
 func TestRunElection_CancelledContext(t *testing.T) {

--- a/internal/ballot/ballot.go
+++ b/internal/ballot/ballot.go
@@ -2,18 +2,15 @@ package ballot
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"slices"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/google/shlex"
 	"github.com/hashicorp/consul/api"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type CommandExecutor interface {
@@ -25,23 +22,23 @@ type consulClient struct {
 }
 
 func (c *consulClient) Agent() AgentInterface {
-	return &AgentWrapper{agent: c.client.Agent()}
+	return c.client.Agent()
 }
 
 func (c *consulClient) Catalog() CatalogInterface {
-	return &CatalogWrapper{catalog: c.client.Catalog()}
+	return c.client.Catalog()
 }
 
 func (c *consulClient) Health() HealthInterface {
-	return &HealthWrapper{health: c.client.Health()}
+	return c.client.Health()
 }
 
 func (c *consulClient) Session() SessionInterface {
-	return &SessionWrapper{session: c.client.Session()}
+	return c.client.Session()
 }
 
 func (c *consulClient) KV() KVInterface {
-	return &KVWrapper{kv: c.client.KV()}
+	return c.client.KV()
 }
 
 // AgentInterface is an interface that wraps the Consul agent methods.
@@ -50,47 +47,15 @@ type AgentInterface interface {
 	ServiceRegister(service *api.AgentServiceRegistration) error
 }
 
-type AgentWrapper struct {
-	agent AgentInterface
-}
-
-func (a *AgentWrapper) ServiceRegister(service *api.AgentServiceRegistration) error {
-	return a.agent.ServiceRegister(service)
-}
-
-func (a *AgentWrapper) Service(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
-	return a.agent.Service(serviceID, q)
-}
-
 // CatalogInterface is an interface that wraps the Consul catalog methods.
 type CatalogInterface interface {
 	Service(serviceName, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error)
 	Register(reg *api.CatalogRegistration, w *api.WriteOptions) (*api.WriteMeta, error)
 }
 
-type CatalogWrapper struct {
-	catalog CatalogInterface
-}
-
-func (c *CatalogWrapper) Service(serviceName, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error) {
-	return c.catalog.Service(serviceName, tag, q)
-}
-
-func (c *CatalogWrapper) Register(reg *api.CatalogRegistration, w *api.WriteOptions) (*api.WriteMeta, error) {
-	return c.catalog.Register(reg, w)
-}
-
 // HealthInterface is an interface that wraps the Consul health methods.
 type HealthInterface interface {
-	Checks(service string, q *api.QueryOptions) ([]*api.HealthCheck, *api.QueryMeta, error)
-}
-
-type HealthWrapper struct {
-	health *api.Health
-}
-
-func (h *HealthWrapper) Checks(service string, q *api.QueryOptions) ([]*api.HealthCheck, *api.QueryMeta, error) {
-	return h.health.Checks(service, q)
+	Checks(service string, q *api.QueryOptions) (api.HealthChecks, *api.QueryMeta, error)
 }
 
 // SessionInterface is an interface that wraps the Consul session methods.
@@ -101,47 +66,11 @@ type SessionInterface interface {
 	RenewPeriodic(initialTTL string, sessionID string, q *api.WriteOptions, doneCh <-chan struct{}) error
 }
 
-type SessionWrapper struct {
-	session SessionInterface
-}
-
-func (s *SessionWrapper) Create(se *api.SessionEntry, q *api.WriteOptions) (string, *api.WriteMeta, error) {
-	return s.session.Create(se, q)
-}
-
-func (s *SessionWrapper) Destroy(sessionID string, q *api.WriteOptions) (*api.WriteMeta, error) {
-	return s.session.Destroy(sessionID, q)
-}
-
-func (s *SessionWrapper) Info(sessionID string, q *api.QueryOptions) (*api.SessionEntry, *api.QueryMeta, error) {
-	return s.session.Info(sessionID, q)
-}
-
-func (s *SessionWrapper) RenewPeriodic(initialTTL string, sessionID string, q *api.WriteOptions, doneCh <-chan struct{}) error {
-	return s.session.RenewPeriodic(initialTTL, sessionID, q, doneCh)
-}
-
 // KVInterface is an interface that wraps the Consul KV methods.
 type KVInterface interface {
 	Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error)
 	Put(p *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error)
 	Acquire(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
-}
-
-type KVWrapper struct {
-	kv KVInterface
-}
-
-func (k *KVWrapper) Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
-	return k.kv.Get(key, q)
-}
-
-func (k *KVWrapper) Put(p *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error) {
-	return k.kv.Put(p, q)
-}
-
-func (k *KVWrapper) Acquire(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
-	return k.kv.Acquire(p, q)
 }
 
 type ConsulClient interface {
@@ -165,135 +94,80 @@ func (c *commandExecutor) CommandContext(ctx context.Context, name string, arg .
 }
 
 // New returns a new Ballot instance.
-func New(ctx context.Context, name string) (*Ballot, error) {
+func New(ctx context.Context, cfg RuntimeConfig) (*Ballot, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context is required")
 	}
+	if err := validateRuntimeConfig(cfg); err != nil {
+		return nil, err
+	}
 	consulConfig := api.DefaultConfig()
-	consulConfig.Token = viper.GetString("consul.token")
-	consulConfig.Address = viper.GetString("consul.address")
+	consulConfig.Token = cfg.ConsulToken
+	consulConfig.Address = cfg.ConsulAddress
 	client, err := api.NewClient(consulConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	b := &Ballot{}
-	err = viper.UnmarshalKey(fmt.Sprintf("election.services.%s", name), b)
-	if err != nil {
-		return nil, err
+	b := &Ballot{
+		Name:          cfg.Name,
+		ID:            cfg.ID,
+		Key:           cfg.Key,
+		ServiceChecks: cfg.ServiceChecks,
+		Token:         consulConfig.Token,
+		ExecOnPromote: cfg.ExecOnPromote,
+		ExecOnDemote:  cfg.ExecOnDemote,
+		PrimaryTag:    cfg.PrimaryTag,
+		ConsulAddress: consulConfig.Address,
+		TTL:           cfg.TTL,
+		LockDelay:     cfg.LockDelay,
+		client:        &consulClient{client: client},
+		ctx:           ctx,
+		executor:      &commandExecutor{},
 	}
-	b.client = &consulClient{client: client}
 	b.leader.Store(false)
-	b.Token = consulConfig.Token
-	b.ctx = ctx
-	b.executor = &commandExecutor{}
-
-	// Ensure that required fields are set
-	if b.ID == "" {
-		return nil, fmt.Errorf("service ID is required; please set the 'id' field in the configuration")
-	}
-	if b.Key == "" {
-		return nil, fmt.Errorf("key is required; please set the 'key' field in the configuration")
-	}
-	if b.Name == "" {
-		b.Name = name
-	}
-	if b.LockDelay == 0 {
-		b.LockDelay = 3 * time.Second
-	}
-	if b.TTL == 0 {
-		b.TTL = 10 * time.Second
-	}
+	b.hooks = NewLeadershipHooks(b.executor)
 
 	return b, nil
 }
 
 // Ballot is a struct that holds the configuration for the leader election.
 type Ballot struct {
-	Name                 string               `mapstructure:"-"`
-	ID                   string               `mapstructure:"id"`
-	Key                  string               `mapstructure:"key"`
-	ServiceChecks        []string             `mapstructure:"serviceChecks"`
-	Token                string               `mapstructure:"consul.token"`
-	ExecOnPromote        string               `mapstructure:"execOnPromote"`
-	ExecOnDemote         string               `mapstructure:"execOnDemote"`
-	PrimaryTag           string               `mapstructure:"primaryTag"`
-	ConsulAddress        string               `mapstructure:"consul.address"`
-	TTL                  time.Duration        `mapstructure:"ttl"`
-	LockDelay            time.Duration        `mapstructure:"lockDelay"`
-	sessionID            atomic.Value         // stores *string
-	leader               atomic.Bool          `mapstructure:"-"`
-	client               ConsulClient         `mapstructure:"-"`
-	ctx                  context.Context      `mapstructure:"-"`
-	executor             CommandExecutor      `mapstructure:"-"`
-	sessionRenewalCancel context.CancelFunc   `mapstructure:"-"`
+	Name             string            `mapstructure:"-"`
+	ID               string            `mapstructure:"id"`
+	Key              string            `mapstructure:"key"`
+	ServiceChecks    []string          `mapstructure:"serviceChecks"`
+	Token            string            `mapstructure:"consul.token"`
+	ExecOnPromote    string            `mapstructure:"execOnPromote"`
+	ExecOnDemote     string            `mapstructure:"execOnDemote"`
+	PrimaryTag       string            `mapstructure:"primaryTag"`
+	ConsulAddress    string            `mapstructure:"consul.address"`
+	TTL              time.Duration     `mapstructure:"ttl"`
+	LockDelay        time.Duration     `mapstructure:"lockDelay"`
+	sessionID        atomic.Value      // stores *string
+	leader           atomic.Bool       `mapstructure:"-"`
+	client           ConsulClient      `mapstructure:"-"`
+	ctx              context.Context   `mapstructure:"-"`
+	executor         CommandExecutor   `mapstructure:"-"`
+	hooks            *LeadershipHooks  `mapstructure:"-"`
+	hookResultsMu    sync.Mutex        `mapstructure:"-"`
+	hookResults      chan HookResult   `mapstructure:"-"`
+	sessionLifecycle *SessionLifecycle `mapstructure:"-"`
 }
 
 // Copy *api.AgentService to *api.AgentServiceRegistration
 func (b *Ballot) copyServiceToRegistration(service *api.AgentService) *api.AgentServiceRegistration {
-	if service == nil {
-		return nil
-	}
-	return &api.AgentServiceRegistration{
-		ID:      service.ID,
-		Name:    service.Service,
-		Tags:    service.Tags,
-		Port:    service.Port,
-		Address: service.Address,
-		Kind:    service.Kind,
-		Weights: &service.Weights,
-		Meta:    service.Meta,
-	}
+	return copyServiceToRegistration(service)
 }
 
 // Copy *api.CatalogService to *api.CatalogRegistration
 func (b *Ballot) copyCatalogServiceToRegistration(service *api.CatalogService) *api.CatalogRegistration {
-	if service == nil {
-		return nil
-	}
-	return &api.CatalogRegistration{
-		ID:              service.ID,
-		Node:            service.Node,
-		Address:         service.ServiceAddress,
-		TaggedAddresses: service.TaggedAddresses,
-		NodeMeta:        service.NodeMeta,
-		Datacenter:      service.Datacenter,
-		Service: &api.AgentService{
-			ID:              service.ServiceID,
-			Service:         service.ServiceName,
-			Tags:            service.ServiceTags,
-			Meta:            service.ServiceMeta,
-			Port:            service.ServicePort,
-			Address:         service.ServiceAddress,
-			TaggedAddresses: service.ServiceTaggedAddresses,
-			Weights: api.AgentWeights{
-				Passing: service.ServiceWeights.Passing,
-				Warning: service.ServiceWeights.Warning,
-			},
-			EnableTagOverride: service.ServiceEnableTagOverride,
-		},
-	}
+	return copyCatalogServiceToRegistration(service)
 }
 
 // getService returns the registered service.
 func (b *Ballot) getService() (service *api.AgentService, catalogServices []*api.CatalogService, err error) {
-	if b.ID == "" {
-		return nil, nil, fmt.Errorf("service ID is empty; please ensure it is set in the configuration")
-	}
-	agent := b.client.Agent()
-	service, _, err = agent.Service(b.ID, &api.QueryOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-	if service == nil {
-		return nil, nil, fmt.Errorf("service %s not found", b.ID)
-	}
-	catalog := b.client.Catalog()
-	catalogServices, _, err = catalog.Service(b.Name, b.PrimaryTag, &api.QueryOptions{})
-	if err != nil {
-		return service, nil, err
-	}
-	return service, catalogServices, nil
+	return b.interaction().LocalService()
 }
 
 // runCommand runs a command and returns the output.
@@ -301,232 +175,74 @@ func (b *Ballot) runCommand(command string, electionPayload *ElectionPayload) ([
 	log.WithFields(log.Fields{
 		"caller": "runCommand",
 	}).Info("Running command: ", command)
-	args, err := shlex.Split(command)
-	if err != nil {
-		return nil, err
-	}
-	if len(args) == 0 {
+	if strings.TrimSpace(command) == "" {
 		return nil, fmt.Errorf("empty command")
 	}
-	cmd := b.executor.CommandContext(b.ctx, args[0], args[1:]...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("ADDRESS=%s", electionPayload.Address),
-		fmt.Sprintf("PORT=%d", electionPayload.Port),
-		fmt.Sprintf("SESSIONID=%s", electionPayload.SessionID),
-	)
-	return cmd.CombinedOutput()
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result := b.leadershipHooks().Execute(ctx, HookRequest{
+		Command: command,
+		Payload: electionPayload,
+		Timeout: HookTimeout(b.TTL, b.LockDelay),
+	})
+	return result.Output, result.Err
 }
 
 // updateServiceTags updates the service tags.
 func (b *Ballot) updateServiceTags(isLeader bool) error {
-	service, _, err := b.getService()
+	changed, err := b.interaction().ApplyPrimaryTag(isLeader)
 	if err != nil {
 		return err
 	}
-
-	// Get a copy of the current service registration
-	registration := b.copyServiceToRegistration(service)
-	if registration == nil {
-		return fmt.Errorf("service registration is nil")
-	}
-
-	// Determine if the primary tag is already present
-	hasPrimaryTag := slices.Contains(registration.Tags, b.PrimaryTag)
-
-	// Update tags based on leadership status
-	if isLeader && !hasPrimaryTag {
-		// Add primary tag if not present and this node is the leader
-		registration.Tags = append(slices.Clone(registration.Tags), b.PrimaryTag)
-	} else if !isLeader && hasPrimaryTag {
-		// Remove primary tag if present and this node is not the leader
-		index := slices.Index(registration.Tags, b.PrimaryTag)
-		registration.Tags = slices.Delete(slices.Clone(registration.Tags), index, index+1)
-	} else {
-		// No changes needed
+	if !changed {
 		return nil
 	}
 
-	// Run the command associated with the new leadership status
 	var command string
 	if isLeader {
 		command = b.ExecOnPromote
 	} else {
 		command = b.ExecOnDemote
 	}
-	if command != "" && b.executor != nil {
-		go func(isLeader bool, command string) {
-			defer func() {
-				if r := recover(); r != nil {
-					log.WithFields(log.Fields{
-						"caller": "updateServiceTags",
-						"error":  r,
-					}).Error("Recovered from panic in command execution")
-				}
-			}()
-
-			// Run the command in a separate goroutine
-			ctx, cancel := context.WithTimeout(b.ctx, (b.TTL+b.LockDelay)*2)
-			defer cancel()
-			payload, payloadErr := b.waitForNextValidSessionData(ctx)
-			if payloadErr != nil {
-				log.WithFields(log.Fields{
-					"caller": "updateServiceTags",
-					"error":  payloadErr,
-				}).Error("Failed to get session data")
-				return
-			}
-			output, cmdErr := b.runCommand(command, payload)
-			if cmdErr != nil {
-				log.WithFields(log.Fields{
-					"caller":   "updateServiceTags",
-					"isLeader": isLeader,
-					"error":    cmdErr,
-				}).Error("Failed to run command")
-			} else {
-				log.WithFields(log.Fields{
-					"caller":   "updateServiceTags",
-					"isLeader": isLeader,
-					"output":   string(output),
-				}).Info("Ran command")
-			}
-		}(isLeader, command)
-	}
-
-	// Log the updated tags
-	log.WithFields(log.Fields{
-		"caller":  "updateServiceTags",
-		"service": b.ID,
-		"tags":    registration.Tags,
-	}).Debug("Updated service tags")
-
-	// Update the service registration with new tags
-	agent := b.client.Agent()
-	return agent.ServiceRegister(registration)
-}
-
-// cleanup is called by the winning service to ensure that the primary tag is removed from all other instances of the service.
-func (b *Ballot) cleanup(payload *ElectionPayload) error {
-	if !b.IsLeader() {
-		// If this instance is not the leader, do not perform cleanup
+	if command == "" || b.executor == nil {
 		return nil
 	}
-
-	catalogServices, _, err := b.client.Catalog().Service(b.Name, "", nil)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve services from the catalog: %s", err)
-	}
-
-	for _, service := range catalogServices {
-		// Skip cleaning up the leader's own service
-		if service.ServiceAddress == payload.Address && service.ServicePort == payload.Port {
-			continue
-		}
-
-		// Check if the primary tag is present
-		primaryTagIndex := slices.Index(service.ServiceTags, b.PrimaryTag)
-		if primaryTagIndex != -1 {
-			// Remove the primary tag (clone to avoid mutating original slice)
-			updatedTags := slices.Delete(slices.Clone(service.ServiceTags), primaryTagIndex, primaryTagIndex+1)
-
-			// Prepare the catalog registration for update
-			catalogRegistration := b.copyCatalogServiceToRegistration(service)
-			if catalogRegistration == nil || catalogRegistration.Service == nil {
-				continue
-			}
-			catalogRegistration.Service.Tags = updatedTags
-
-			// Update the catalog service
-			_, err := b.client.Catalog().Register(catalogRegistration, nil)
-			if err != nil {
-				return fmt.Errorf("failed to update service tags in the catalog: %s", err)
-			}
-
-			log.WithFields(log.Fields{
-				"caller":  "cleanup",
-				"service": service.ServiceID,
-				"node":    service.Node,
-				"tags":    updatedTags,
-			}).Info("Cleaned up primary tag from service")
-		}
+	result := b.executeLeadershipHook(isLeader, command)
+	if result.Err != nil {
+		log.WithFields(log.Fields{
+			"caller":   "updateServiceTags",
+			"isLeader": isLeader,
+			"error":    result.Err,
+		}).Error("Failed to run command")
+	} else if !result.Skipped {
+		log.WithFields(log.Fields{
+			"caller":   "updateServiceTags",
+			"isLeader": isLeader,
+			"output":   string(result.Output),
+		}).Info("Ran command")
 	}
 	return nil
 }
 
+// cleanup is called by the winning service to ensure that the primary tag is removed from all other instances of the service.
+func (b *Ballot) cleanup(payload *ElectionPayload) error {
+	return b.interaction().CleanupStalePrimaryTags(payload, b.IsLeader())
+}
+
 // election is the main logic for the leader election.
 func (b *Ballot) election() error {
-	err := b.handleServiceCriticalState()
-	if err != nil {
-		return err
-	}
-
-	service, _, err := b.getService()
-	if err != nil {
-		return fmt.Errorf("failed to get service: %s", err)
-	}
-
-	// Session validation and renewal
-	err = b.session()
-	if err != nil {
-		return fmt.Errorf("failed to create session: %s", err)
-	}
-
-	// Prepare the election payload
-	sessionIDPtr, ok := b.getSessionID()
-	if !ok || sessionIDPtr == nil {
-		return fmt.Errorf("session ID is nil")
-	}
-	electionPayload := &ElectionPayload{
-		Address:   service.Address,
-		Port:      service.Port,
-		SessionID: *sessionIDPtr,
-	}
-
-	// Attempt to acquire leadership
-	if !b.leader.Load() && sessionIDPtr != nil {
-		acquired, _, err := b.attemptLeadershipAcquisition(electionPayload)
-		if err != nil {
-			return fmt.Errorf("failed to acquire lock: %s", err)
-		}
-		if acquired {
-			log.WithFields(log.Fields{
-				"caller": "election",
-			}).Info("Acquired leadership")
-		}
-	}
-
-	err = b.cleanup(electionPayload)
-	if err != nil {
-		return fmt.Errorf("failed to cleanup: %s", err)
-	}
-
-	// Check leadership status and respond accordingly
-	return b.verifyAndUpdateLeadershipStatus()
+	return NewElectionStep(b).Run().Err
 }
 
 // attemptLeadershipAcquisition attempts to acquire leadership.
 func (b *Ballot) attemptLeadershipAcquisition(electionPayload *ElectionPayload) (bool, *api.WriteMeta, error) {
-	payload, err := json.Marshal(electionPayload)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to marshal election payload: %s", err)
-	}
-
 	sessionIDPtr, ok := b.getSessionID()
 	if !ok || sessionIDPtr == nil {
 		return false, nil, fmt.Errorf("session ID is nil")
 	}
-
-	content := &api.KVPair{
-		Key:     b.Key,
-		Session: *sessionIDPtr,
-		Value:   payload,
-	}
-
-	acquired, meta, err := b.client.KV().Acquire(content, nil)
-	if err != nil {
-		return false, meta, err
-	}
-
-	return acquired, meta, nil
+	return b.interaction().AcquireLeadership(electionPayload, *sessionIDPtr)
 }
 
 // verifyAndUpdateLeadershipStatus checks the current session data and updates the leadership status.
@@ -598,30 +314,10 @@ func (b *Ballot) updateLeadershipStatus(isLeader bool) error {
 
 // handleServiceCriticalState is called when the service is in a critical state.
 func (b *Ballot) handleServiceCriticalState() error {
-	healthChecks, _, err := b.client.Health().Checks(b.Name, nil)
+	state, err := b.interaction().HealthState()
 	if err != nil {
-		return fmt.Errorf("failed to get health checks: %s", err)
+		return err
 	}
-
-	// Determine the aggregate status, filtering to only this instance's checks
-	state := "passing"
-	for _, check := range healthChecks {
-		// Only consider checks for this specific service instance
-		if check.ServiceID != b.ID {
-			continue
-		}
-		// If ServiceChecks is configured, only consider those specific checks
-		if len(b.ServiceChecks) > 0 && !slices.Contains(b.ServiceChecks, check.CheckID) {
-			continue
-		}
-		if check.Status == "critical" {
-			state = "critical"
-			break
-		} else if check.Status == "warning" {
-			state = "warning"
-		}
-	}
-
 	if state == "critical" {
 		err := b.releaseSession()
 		if err != nil {
@@ -641,70 +337,8 @@ func (b *Ballot) session() error {
 	if b.client == nil {
 		return fmt.Errorf("consul client is required")
 	}
-	sessionIDPtr, ok := b.getSessionID()
-	if ok && sessionIDPtr != nil {
-		currentSessionID := *sessionIDPtr
-		sessionInfo, _, err := b.client.Session().Info(currentSessionID, nil)
-		if err != nil {
-			return err
-		}
-		if sessionInfo != nil {
-			log.WithFields(log.Fields{
-				"caller":  "session",
-				"session": currentSessionID,
-			}).Trace("Returning cached session")
-			return nil
-		}
-	}
-
-	// Cancel the previous session renewal goroutine if it exists
-	if b.sessionRenewalCancel != nil {
-		b.sessionRenewalCancel()
-	}
-
-	log.WithFields(log.Fields{
-		"caller": "session",
-	}).Trace("Creating new session")
-	sessionID, _, err := b.client.Session().Create(&api.SessionEntry{
-		Behavior:  "delete",
-		Checks:    append(slices.Clone(b.ServiceChecks), "serfHealth"),
-		TTL:       b.TTL.String(),
-		LockDelay: b.LockDelay,
-	}, nil)
-	if err != nil {
-		return err
-	}
-
-	log.WithFields(log.Fields{
-		"caller": "session",
-		"ID":     sessionID,
-	}).Trace("Storing session ID")
-	b.sessionID.Store(&sessionID)
-
-	// Create a cancellable context for the renewal goroutine
-	renewCtx, renewCancel := context.WithCancel(b.ctx)
-	b.sessionRenewalCancel = renewCancel
-
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				log.WithFields(log.Fields{
-					"caller": "session",
-					"error":  r,
-				}).Error("Recovered from panic in session renewal")
-			}
-		}()
-
-		err := b.client.Session().RenewPeriodic(b.TTL.String(), sessionID, nil, renewCtx.Done())
-		if err != nil {
-			log.WithFields(log.Fields{
-				"caller": "session",
-				"error":  err,
-			}).Warning("Failed to renew session")
-			b.sessionID.Store((*string)(nil))
-		}
-	}()
-	return nil
+	_, err := b.lifecycle().ActiveSession()
+	return err
 }
 
 func (b *Ballot) getSessionID() (*string, bool) {
@@ -714,6 +348,102 @@ func (b *Ballot) getSessionID() (*string, bool) {
 	}
 	sessionIDPtr, ok := sessionIDValue.(*string)
 	return sessionIDPtr, ok
+}
+
+func (b *Ballot) runtimeConfig() RuntimeConfig {
+	return RuntimeConfig{
+		Name:          b.Name,
+		ID:            b.ID,
+		Key:           b.Key,
+		ServiceChecks: b.ServiceChecks,
+		ConsulToken:   b.Token,
+		ExecOnPromote: b.ExecOnPromote,
+		ExecOnDemote:  b.ExecOnDemote,
+		PrimaryTag:    b.PrimaryTag,
+		ConsulAddress: b.ConsulAddress,
+		TTL:           b.TTL,
+		LockDelay:     b.LockDelay,
+	}
+}
+
+func (b *Ballot) interaction() *ConsulElectionInteraction {
+	return NewConsulElectionInteraction(b.client, b.runtimeConfig())
+}
+
+func (b *Ballot) lifecycle() *SessionLifecycle {
+	if b.sessionLifecycle == nil {
+		b.sessionLifecycle = NewSessionLifecycle(b.ctx, b.client.Session(), &b.sessionID, b.runtimeConfig())
+	}
+	return b.sessionLifecycle
+}
+
+func (b *Ballot) leadershipHooks() *LeadershipHooks {
+	if b.hooks == nil {
+		b.hooks = NewLeadershipHooks(b.executor)
+	}
+	return b.hooks
+}
+
+func (b *Ballot) executeLeadershipHook(isLeader bool, command string) HookResult {
+	transition := HookDemote
+	if isLeader {
+		transition = HookPromote
+	}
+
+	baseCtx := b.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, HookTimeout(b.TTL, b.LockDelay))
+	defer cancel()
+
+	payload, err := b.waitForNextValidSessionData(ctx)
+	if err != nil {
+		result := HookResult{
+			Transition: transition,
+			Command:    command,
+			Err:        err,
+			TimedOut:   ctx.Err() == context.DeadlineExceeded,
+		}
+		b.publishHookResult(result)
+		return result
+	}
+
+	result := b.leadershipHooks().Execute(baseCtx, HookRequest{
+		Transition: transition,
+		Command:    command,
+		Payload:    payload,
+		Timeout:    HookTimeout(b.TTL, b.LockDelay),
+	})
+	b.publishHookResult(result)
+	return result
+}
+
+func (b *Ballot) publishHookResult(result HookResult) {
+	results := b.hookResultsChan()
+	select {
+	case results <- result:
+	default:
+	}
+}
+
+func (b *Ballot) ObserveHookResult(ctx context.Context) (HookResult, bool) {
+	results := b.hookResultsChan()
+	select {
+	case result := <-results:
+		return result, true
+	case <-ctx.Done():
+		return HookResult{Err: ctx.Err()}, false
+	}
+}
+
+func (b *Ballot) hookResultsChan() chan HookResult {
+	b.hookResultsMu.Lock()
+	defer b.hookResultsMu.Unlock()
+	if b.hookResults == nil {
+		b.hookResults = make(chan HookResult, 8)
+	}
+	return b.hookResults
 }
 
 func (b *Ballot) IsLeader() bool {
@@ -728,15 +458,15 @@ func (b *Ballot) waitForNextValidSessionData(ctx context.Context) (*ElectionPayl
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 	for {
+		data, err := b.getSessionData()
+		if err != nil {
+			return data, err
+		}
+		if data != nil {
+			return data, nil
+		}
 		select {
 		case <-ticker.C:
-			data, err := b.getSessionData()
-			if err != nil {
-				return data, err
-			}
-			if data != nil {
-				return data, nil
-			}
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -744,32 +474,19 @@ func (b *Ballot) waitForNextValidSessionData(ctx context.Context) (*ElectionPayl
 }
 
 func (b *Ballot) getSessionData() (*ElectionPayload, error) {
-	sessionKey, _, err := b.client.KV().Get(b.Key, nil)
-	if err != nil {
-		return nil, err
-	}
-	if sessionKey == nil {
-		return nil, nil
-	}
-	var data *ElectionPayload
-	err = json.Unmarshal(sessionKey.Value, &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return b.interaction().LockPayload()
 }
 
 // releaseSession releases the session.
 func (b *Ballot) releaseSession() error {
+	if b.sessionLifecycle != nil {
+		return b.sessionLifecycle.Release()
+	}
 	sessionIDPtr, ok := b.getSessionID()
 	if !ok || sessionIDPtr == nil {
 		return nil
 	}
 	sessionID := *sessionIDPtr
-	// Always clear the local session state, even if Destroy fails.
-	// The session may have already been invalidated by Consul (e.g., due to
-	// health check failure), but we should still clear our local state.
 	b.sessionID.Store((*string)(nil))
 	_, err := b.client.Session().Destroy(sessionID, nil)
 	return err

--- a/internal/ballot/ballot_integration_test.go
+++ b/internal/ballot/ballot_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,17 +79,17 @@ func cleanupKV(t *testing.T, client *api.Client, key string) {
 	}
 }
 
-func setupViper(t *testing.T, serviceID string, electionKey string) {
-	t.Helper()
-	viper.Reset()
-	viper.Set("consul.address", getConsulAddr())
-	viper.Set("consul.token", "")
-	viper.Set(fmt.Sprintf("election.services.%s.id", serviceID), serviceID)
-	viper.Set(fmt.Sprintf("election.services.%s.key", serviceID), electionKey)
-	viper.Set(fmt.Sprintf("election.services.%s.primaryTag", serviceID), testPrimaryTag)
-	viper.Set(fmt.Sprintf("election.services.%s.serviceChecks", serviceID), []string{fmt.Sprintf("service:%s", serviceID)})
-	viper.Set(fmt.Sprintf("election.services.%s.ttl", serviceID), "10s")
-	viper.Set(fmt.Sprintf("election.services.%s.lockDelay", serviceID), "1s")
+func testRuntimeConfig(serviceID string, electionKey string) RuntimeConfig {
+	return RuntimeConfig{
+		Name:          serviceID,
+		ID:            serviceID,
+		Key:           electionKey,
+		PrimaryTag:    testPrimaryTag,
+		ServiceChecks: []string{fmt.Sprintf("service:%s", serviceID)},
+		ConsulAddress: getConsulAddr(),
+		TTL:           10 * time.Second,
+		LockDelay:     time.Second,
+	}
 }
 
 func TestIntegration_FullElectionCycle(t *testing.T) {
@@ -104,15 +103,11 @@ func TestIntegration_FullElectionCycle(t *testing.T) {
 	defer deregisterTestService(t, client, serviceID)
 	defer cleanupKV(t, client, electionKey)
 
-	// Setup viper configuration
-	setupViper(t, serviceID, electionKey)
-	defer viper.Reset()
-
 	// Create ballot instance
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	ballot, err := New(ctx, serviceID)
+	ballot, err := New(ctx, testRuntimeConfig(serviceID, electionKey))
 	require.NoError(t, err, "Failed to create Ballot instance")
 	defer ballot.releaseSession()
 
@@ -157,20 +152,13 @@ func TestIntegration_LeaderFailover(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Setup and create first ballot
-	// Note: Ballot copies config at creation time, so resetting viper after
-	// ballot1 is created won't affect it.
-	setupViper(t, serviceID1, electionKey)
-	ballot1, err := New(ctx, serviceID1)
+	ballot1, err := New(ctx, testRuntimeConfig(serviceID1, electionKey))
 	require.NoError(t, err)
 	defer ballot1.releaseSession()
 
-	// Setup and create second ballot with fresh viper config
-	setupViper(t, serviceID2, electionKey)
-	ballot2, err := New(ctx, serviceID2)
+	ballot2, err := New(ctx, testRuntimeConfig(serviceID2, electionKey))
 	require.NoError(t, err)
 	defer ballot2.releaseSession()
-	defer viper.Reset()
 
 	// First ballot becomes leader
 	err = ballot1.election()
@@ -190,13 +178,10 @@ func TestIntegration_LeaderFailover(t *testing.T) {
 	_, err = client.Session().Destroy(*sessionID1, nil)
 	require.NoError(t, err, "Failed to destroy session")
 
-	// Wait for lock delay to pass
-	time.Sleep(2 * time.Second)
-
-	// Second ballot should now be able to become leader
-	err = ballot2.election()
-	require.NoError(t, err)
-	assert.True(t, ballot2.IsLeader(), "Ballot 2 should be leader after failover")
+	require.Eventually(t, func() bool {
+		err = ballot2.election()
+		return err == nil && ballot2.IsLeader()
+	}, 5*time.Second, 100*time.Millisecond, "Ballot 2 should be leader after failover")
 
 	// Verify primary tag moved to second service
 	service2, _, err := client.Agent().Service(serviceID2, nil)
@@ -214,13 +199,10 @@ func TestIntegration_TagPromotion(t *testing.T) {
 	defer deregisterTestService(t, client, serviceID)
 	defer cleanupKV(t, client, electionKey)
 
-	setupViper(t, serviceID, electionKey)
-	defer viper.Reset()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	ballot, err := New(ctx, serviceID)
+	ballot, err := New(ctx, testRuntimeConfig(serviceID, electionKey))
 	require.NoError(t, err)
 	defer ballot.releaseSession()
 
@@ -251,13 +233,10 @@ func TestIntegration_HealthCheckFailure(t *testing.T) {
 	defer deregisterTestService(t, client, serviceID)
 	defer cleanupKV(t, client, electionKey)
 
-	setupViper(t, serviceID, electionKey)
-	defer viper.Reset()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	ballot, err := New(ctx, serviceID)
+	ballot, err := New(ctx, testRuntimeConfig(serviceID, electionKey))
 	require.NoError(t, err)
 	defer ballot.releaseSession()
 
@@ -314,14 +293,12 @@ func TestIntegration_MultipleInstances(t *testing.T) {
 		registerTestService(t, client, services[i], 8090+i)
 		defer deregisterTestService(t, client, services[i])
 
-		setupViper(t, services[i], electionKey)
-		b, err := New(ctx, services[i])
+		b, err := New(ctx, testRuntimeConfig(services[i], electionKey))
 		require.NoError(t, err)
 		defer b.releaseSession()
 		ballots[i] = b
 	}
 	defer cleanupKV(t, client, electionKey)
-	defer viper.Reset()
 
 	// Run elections for all instances
 	for i, b := range ballots {
@@ -364,21 +341,10 @@ func TestIntegration_SessionRenewal(t *testing.T) {
 	defer deregisterTestService(t, client, serviceID)
 	defer cleanupKV(t, client, electionKey)
 
-	// Use short TTL to test renewal
-	viper.Reset()
-	viper.Set("consul.address", getConsulAddr())
-	viper.Set(fmt.Sprintf("election.services.%s.id", serviceID), serviceID)
-	viper.Set(fmt.Sprintf("election.services.%s.key", serviceID), electionKey)
-	viper.Set(fmt.Sprintf("election.services.%s.primaryTag", serviceID), testPrimaryTag)
-	viper.Set(fmt.Sprintf("election.services.%s.serviceChecks", serviceID), []string{fmt.Sprintf("service:%s", serviceID)})
-	viper.Set(fmt.Sprintf("election.services.%s.ttl", serviceID), "10s")
-	viper.Set(fmt.Sprintf("election.services.%s.lockDelay", serviceID), "1s")
-	defer viper.Reset()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	ballot, err := New(ctx, serviceID)
+	ballot, err := New(ctx, testRuntimeConfig(serviceID, electionKey))
 	require.NoError(t, err)
 	defer ballot.releaseSession()
 
@@ -391,13 +357,14 @@ func TestIntegration_SessionRenewal(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, sessionID)
 
-	// Wait longer than TTL/2 but less than TTL to verify session is still valid
-	time.Sleep(6 * time.Second)
-
-	// Session should still be valid due to renewal
-	sessionInfo, _, err := client.Session().Info(*sessionID, nil)
-	require.NoError(t, err)
-	assert.NotNil(t, sessionInfo, "Session should still exist after renewal")
+	renewalWindow := time.Now().Add(6 * time.Second)
+	require.Eventually(t, func() bool {
+		if time.Now().Before(renewalWindow) {
+			return false
+		}
+		sessionInfo, _, err := client.Session().Info(*sessionID, nil)
+		return err == nil && sessionInfo != nil
+	}, 8*time.Second, 100*time.Millisecond, "Session should still exist after renewal")
 
 	// Run another election - should maintain leadership
 	err = ballot.election()

--- a/internal/ballot/ballot_test.go
+++ b/internal/ballot/ballot_test.go
@@ -11,70 +11,61 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestNew(t *testing.T) {
-	t.Run("successful new", func(t *testing.T) {
-		// Set up the necessary configuration
-		viper.Set("election.services.test.id", "test_service_id")
-		viper.Set("election.services.test.key", "election/test_service/leader")
-		viper.Set("election.services.test.primaryTag", "primary")
-		viper.Set("election.services.test.serviceChecks", []string{"service:test_service_id"})
-		viper.Set("election.services.test.execOnPromote", "echo Promoted to leader")
-		viper.Set("election.services.test.execOnDemote", "echo Demoted from leader")
-		viper.Set("election.services.test.ttl", "10s")
-		viper.Set("election.services.test.lockDelay", "3s")
-
-		// Ensure viper configuration is reset after the test
-		defer func() {
-			viper.Reset()
-		}()
-
-		// Call the New function
-		b, err := New(context.Background(), "test")
+	t.Run("successful new from runtime config", func(t *testing.T) {
+		b, err := New(context.Background(), RuntimeConfig{
+			Name:          "test",
+			ID:            "test_service_id",
+			Key:           "election/test_service/leader",
+			PrimaryTag:    "primary",
+			ServiceChecks: []string{"service:test_service_id"},
+			ExecOnPromote: "echo Promoted to leader",
+			ExecOnDemote:  "echo Demoted from leader",
+			TTL:           10 * time.Second,
+			LockDelay:     3 * time.Second,
+		})
 		assert.NoError(t, err)
 		assert.NotNil(t, b)
-
-		// Verify that the Ballot instance has the expected values
 		assert.Equal(t, "test_service_id", b.ID)
 		assert.Equal(t, "election/test_service/leader", b.Key)
 		assert.Equal(t, "primary", b.PrimaryTag)
 	})
 
 	t.Run("failure due to nil context", func(t *testing.T) {
-		b, err := New(nil, "test")
+		b, err := New(nil, RuntimeConfig{
+			Name:      "test",
+			ID:        "test_service_id",
+			Key:       "election/test_service/leader",
+			TTL:       10 * time.Second,
+			LockDelay: 3 * time.Second,
+		})
 		assert.Error(t, err)
 		assert.Nil(t, b)
 	})
 
 	t.Run("failure due to missing key", func(t *testing.T) {
-		// Set up configuration without the key field
-		viper.Set("election.services.nokey.id", "test_service_id")
-		viper.Set("election.services.nokey.primaryTag", "primary")
-
-		defer func() {
-			viper.Reset()
-		}()
-
-		b, err := New(context.Background(), "nokey")
+		b, err := New(context.Background(), RuntimeConfig{
+			Name:      "nokey",
+			ID:        "test_service_id",
+			TTL:       10 * time.Second,
+			LockDelay: 3 * time.Second,
+		})
 		assert.Error(t, err)
 		assert.Nil(t, b)
 		assert.Contains(t, err.Error(), "key is required")
 	})
 
 	t.Run("failure due to missing id", func(t *testing.T) {
-		// Set up configuration without the id field
-		viper.Set("election.services.noid.key", "election/test/leader")
-		viper.Set("election.services.noid.primaryTag", "primary")
-
-		defer func() {
-			viper.Reset()
-		}()
-
-		b, err := New(context.Background(), "noid")
+		b, err := New(context.Background(), RuntimeConfig{
+			Name:      "noid",
+			Key:       "election/test/leader",
+			TTL:       10 * time.Second,
+			LockDelay: 3 * time.Second,
+		})
 		assert.Error(t, err)
 		assert.Nil(t, b)
 		assert.Contains(t, err.Error(), "service ID is required")
@@ -177,7 +168,7 @@ func TestRunCommand(t *testing.T) {
 		// Set up the expectation
 		// Here, we're using a command that just outputs "mocked" when run
 		mockCmd := exec.Command("echo", "mocked")
-		mockExecutor.On("CommandContext", b.ctx, "echo", []string{"hello"}).Return(mockCmd)
+		mockExecutor.On("CommandContext", mock.Anything, "echo", []string{"hello"}).Return(mockCmd)
 
 		// Call the method under test
 		_, err := b.runCommand(command, payload)
@@ -461,8 +452,7 @@ func TestSession(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, firstSessionID, *storedSessionID)
 
-		// Verify sessionRenewalCancel is set
-		assert.NotNil(t, b.sessionRenewalCancel)
+		assert.NotNil(t, b.sessionLifecycle)
 
 		// Create second session - should cancel the first renewal
 		err = b.session()
@@ -1477,6 +1467,7 @@ func TestElection(t *testing.T) {
 		// Mock Catalog
 		mockCatalog := new(MockCatalog)
 		mockCatalog.On("Service", b.Name, b.PrimaryTag, mock.Anything).Return([]*api.CatalogService{}, nil, nil)
+		mockCatalog.On("Service", b.Name, "", mock.Anything).Return([]*api.CatalogService{}, nil, nil)
 		mockCatalog.On("Register", mock.Anything, mock.Anything).Return(nil, nil)
 
 		// Set up the mock client
@@ -1499,423 +1490,6 @@ func TestElection(t *testing.T) {
 		// Verify that b.IsLeader() returns true
 		assert.True(t, b.IsLeader(), "Expected b.IsLeader() to return true after successful election")
 	})
-}
-
-func TestAgentWrapper_ServiceRegister(t *testing.T) {
-	// Arrange
-	mockAgent := new(MockAgent)
-	agentWrapper := &AgentWrapper{agent: mockAgent}
-
-	serviceReg := &api.AgentServiceRegistration{
-		Name: "test_service",
-	}
-
-	expectedErr := errors.New("registration error")
-	mockAgent.On("ServiceRegister", serviceReg).Return(expectedErr)
-
-	// Act
-	err := agentWrapper.ServiceRegister(serviceReg)
-
-	// Assert
-	assert.Equal(t, expectedErr, err)
-	mockAgent.AssertCalled(t, "ServiceRegister", serviceReg)
-}
-
-func TestAgentWrapper_Service(t *testing.T) {
-	// Arrange
-	mockAgent := new(MockAgent)
-	agentWrapper := &AgentWrapper{agent: mockAgent}
-
-	serviceID := "test_service_id"
-	queryOptions := &api.QueryOptions{}
-
-	expectedService := &api.AgentService{ID: serviceID}
-	expectedMeta := &api.QueryMeta{}
-	expectedErr := errors.New("service error")
-
-	mockAgent.On("Service", serviceID, queryOptions).Return(expectedService, expectedMeta, expectedErr)
-
-	// Act
-	service, meta, err := agentWrapper.Service(serviceID, queryOptions)
-
-	// Assert
-	assert.Equal(t, expectedService, service)
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockAgent.AssertCalled(t, "Service", serviceID, queryOptions)
-}
-
-func TestCatalogWrapper_Service(t *testing.T) {
-	// Arrange
-	mockCatalog := new(MockCatalog)
-	catalogWrapper := &CatalogWrapper{catalog: mockCatalog}
-
-	serviceName := "test_service"
-	tag := "test_tag"
-	queryOptions := &api.QueryOptions{}
-
-	expectedServices := []*api.CatalogService{
-		{ServiceName: serviceName},
-	}
-	expectedMeta := &api.QueryMeta{}
-	expectedErr := errors.New("catalog service error")
-
-	mockCatalog.On("Service", serviceName, tag, queryOptions).Return(expectedServices, expectedMeta, expectedErr)
-
-	// Act
-	services, meta, err := catalogWrapper.Service(serviceName, tag, queryOptions)
-
-	// Assert
-	assert.Equal(t, expectedServices, services)
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockCatalog.AssertCalled(t, "Service", serviceName, tag, queryOptions)
-}
-
-func TestCatalogWrapper_Register(t *testing.T) {
-	// Arrange
-	mockCatalog := new(MockCatalog)
-	catalogWrapper := &CatalogWrapper{catalog: mockCatalog}
-
-	registration := &api.CatalogRegistration{}
-	writeOptions := &api.WriteOptions{}
-
-	expectedMeta := &api.WriteMeta{}
-	expectedErr := errors.New("register error")
-
-	mockCatalog.On("Register", registration, writeOptions).Return(expectedMeta, expectedErr)
-
-	// Act
-	meta, err := catalogWrapper.Register(registration, writeOptions)
-
-	// Assert
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockCatalog.AssertCalled(t, "Register", registration, writeOptions)
-}
-
-func TestSessionWrapper_Create(t *testing.T) {
-	// Arrange
-	mockSession := new(MockSession)
-	sessionWrapper := &SessionWrapper{session: mockSession}
-
-	sessionEntry := &api.SessionEntry{}
-	writeOptions := &api.WriteOptions{}
-
-	expectedID := "session_id"
-	expectedMeta := &api.WriteMeta{}
-	expectedErr := errors.New("session create error")
-
-	mockSession.On("Create", sessionEntry, writeOptions).Return(expectedID, expectedMeta, expectedErr)
-
-	// Act
-	sessionID, meta, err := sessionWrapper.Create(sessionEntry, writeOptions)
-
-	// Assert
-	assert.Equal(t, expectedID, sessionID)
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockSession.AssertCalled(t, "Create", sessionEntry, writeOptions)
-}
-
-func TestSessionWrapper_RenewPeriodic(t *testing.T) {
-	// Arrange
-	mockSession := new(MockSession)
-	sessionWrapper := &SessionWrapper{session: mockSession}
-
-	initialTTL := "15s"
-	sessionID := "session_id"
-	writeOptions := &api.WriteOptions{}
-	doneCh := make(chan struct{})
-	// Convert to receive-only channel
-	var receiveOnlyDoneCh <-chan struct{} = doneCh
-
-	expectedErr := errors.New("renew error")
-
-	mockSession.On("RenewPeriodic", initialTTL, sessionID, writeOptions, receiveOnlyDoneCh).Return(expectedErr)
-
-	// Act
-	err := sessionWrapper.RenewPeriodic(initialTTL, sessionID, writeOptions, receiveOnlyDoneCh)
-
-	// Assert
-	assert.Equal(t, expectedErr, err)
-	mockSession.AssertCalled(t, "RenewPeriodic", initialTTL, sessionID, writeOptions, receiveOnlyDoneCh)
-}
-
-func TestKVWrapper_Get(t *testing.T) {
-	// Arrange
-	mockKV := new(MockKV)
-	kvWrapper := &KVWrapper{kv: mockKV}
-
-	key := "test_key"
-	queryOptions := &api.QueryOptions{}
-
-	expectedKVPair := &api.KVPair{Key: key}
-	expectedMeta := &api.QueryMeta{}
-	expectedErr := errors.New("get error")
-
-	mockKV.On("Get", key, queryOptions).Return(expectedKVPair, expectedMeta, expectedErr)
-
-	// Act
-	kvPair, meta, err := kvWrapper.Get(key, queryOptions)
-
-	// Assert
-	assert.Equal(t, expectedKVPair, kvPair)
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockKV.AssertCalled(t, "Get", key, queryOptions)
-}
-
-func TestKVWrapper_Acquire(t *testing.T) {
-	// Arrange
-	mockKV := new(MockKV)
-	kvWrapper := &KVWrapper{kv: mockKV}
-
-	kvPair := &api.KVPair{Key: "test_key"}
-	writeOptions := &api.WriteOptions{}
-
-	expectedSuccess := true
-	expectedMeta := &api.WriteMeta{}
-	expectedErr := errors.New("acquire error")
-
-	mockKV.On("Acquire", kvPair, writeOptions).Return(expectedSuccess, expectedMeta, expectedErr)
-
-	// Act
-	success, meta, err := kvWrapper.Acquire(kvPair, writeOptions)
-
-	// Assert
-	assert.Equal(t, expectedSuccess, success)
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockKV.AssertCalled(t, "Acquire", kvPair, writeOptions)
-}
-
-// MockConsulClient is a mock implementation of the api.Client interface
-type MockConsulClient struct {
-	mock.Mock
-}
-
-func (m *MockConsulClient) Agent() AgentInterface {
-	args := m.Called()
-	return args.Get(0).(AgentInterface)
-}
-
-func (m *MockConsulClient) Catalog() CatalogInterface {
-	args := m.Called()
-	return args.Get(0).(CatalogInterface)
-}
-
-func (m *MockConsulClient) Health() HealthInterface {
-	args := m.Called()
-	return args.Get(0).(HealthInterface)
-}
-
-func (m *MockConsulClient) KV() KVInterface {
-	args := m.Called()
-	return args.Get(0).(KVInterface)
-}
-
-func (m *MockConsulClient) Session() SessionInterface {
-	args := m.Called()
-	return args.Get(0).(SessionInterface)
-}
-
-// MockAgent is a mock implementation of the api.Agent interface
-type MockAgent struct {
-	mock.Mock
-}
-
-func (m *MockAgent) Service(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
-	args := m.Called(serviceID, q)
-	var service *api.AgentService
-	if args.Get(0) != nil {
-		service = args.Get(0).(*api.AgentService)
-	}
-	var meta *api.QueryMeta
-	if args.Get(1) != nil {
-		meta = args.Get(1).(*api.QueryMeta)
-	}
-	return service, meta, args.Error(2)
-}
-
-func (m *MockAgent) ServiceRegister(service *api.AgentServiceRegistration) error {
-	args := m.Called(service)
-	return args.Error(0)
-}
-
-func (m *MockAgent) ServiceDeregister(serviceID string) error {
-	args := m.Called(serviceID)
-	return args.Error(0)
-}
-
-// MockCatalog is a mock implementation of the api.Catalog interface
-type MockCatalog struct {
-	mock.Mock
-}
-
-func (m *MockCatalog) Service(serviceName, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error) {
-	args := m.Called(serviceName, tag, q)
-	var services []*api.CatalogService
-	if args.Get(0) != nil {
-		services = args.Get(0).([]*api.CatalogService)
-	}
-	var meta *api.QueryMeta
-	if args.Get(1) != nil {
-		meta = args.Get(1).(*api.QueryMeta)
-	}
-	return services, meta, args.Error(2)
-}
-
-func (m *MockCatalog) Register(reg *api.CatalogRegistration, w *api.WriteOptions) (*api.WriteMeta, error) {
-	args := m.Called(reg, w)
-	var meta *api.WriteMeta
-	if args.Get(0) != nil {
-		meta = args.Get(0).(*api.WriteMeta)
-	}
-	return meta, args.Error(1)
-}
-
-func (m *MockCatalog) Deregister(dereg *api.CatalogDeregistration, w *api.WriteOptions) (*api.WriteMeta, error) {
-	args := m.Called(dereg, w)
-	var meta *api.WriteMeta
-	if args.Get(0) != nil {
-		meta = args.Get(0).(*api.WriteMeta)
-	}
-	return meta, args.Error(1)
-}
-
-// MockSession is a mock implementation of the api.Session interface
-type MockSession struct {
-	mock.Mock
-}
-
-func (m *MockSession) Create(se *api.SessionEntry, q *api.WriteOptions) (string, *api.WriteMeta, error) {
-	args := m.Called(se, q)
-	sessionID := args.String(0)
-	var meta *api.WriteMeta
-	if args.Get(1) != nil {
-		meta = args.Get(1).(*api.WriteMeta)
-	}
-	return sessionID, meta, args.Error(2)
-}
-
-func (m *MockSession) Destroy(sessionID string, q *api.WriteOptions) (*api.WriteMeta, error) {
-	args := m.Called(sessionID, q)
-	var meta *api.WriteMeta
-	if args.Get(0) != nil {
-		meta = args.Get(0).(*api.WriteMeta)
-	}
-	return meta, args.Error(1)
-}
-
-func (m *MockSession) Info(sessionID string, q *api.QueryOptions) (*api.SessionEntry, *api.QueryMeta, error) {
-	args := m.Called(sessionID, q)
-	return args.Get(0).(*api.SessionEntry), args.Get(1).(*api.QueryMeta), args.Error(2)
-}
-
-func (m *MockSession) RenewPeriodic(initialTTL string, id string, q *api.WriteOptions, doneCh <-chan struct{}) error {
-	args := m.Called(initialTTL, id, q, doneCh)
-	return args.Error(0)
-}
-
-// MockHealth is a mock implementation of the api.Health interface
-type MockHealth struct {
-	mock.Mock
-}
-
-func (m *MockHealth) Checks(service string, q *api.QueryOptions) ([]*api.HealthCheck, *api.QueryMeta, error) {
-	args := m.Called(service, q)
-	checks, _ := args.Get(0).([]*api.HealthCheck)
-	meta, _ := args.Get(1).(*api.QueryMeta)
-	return checks, meta, args.Error(2)
-}
-
-// MockKV is a mock implementation of the api.KV interface
-type MockKV struct {
-	mock.Mock
-}
-
-func (m *MockKV) Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
-	args := m.Called(key, q)
-	pair, _ := args.Get(0).(*api.KVPair)
-	meta, _ := args.Get(1).(*api.QueryMeta)
-	return pair, meta, args.Error(2)
-}
-
-func (m *MockKV) Put(p *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error) {
-	args := m.Called(p, q)
-	meta, _ := args.Get(0).(*api.WriteMeta)
-	return meta, args.Error(1)
-}
-
-func (m *MockKV) Acquire(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
-	args := m.Called(p, q)
-	boolResult := args.Bool(0)
-	var meta *api.WriteMeta
-	if args.Get(1) != nil {
-		meta = args.Get(1).(*api.WriteMeta)
-	}
-	errResult := args.Error(2)
-	return boolResult, meta, errResult
-}
-
-func TestSessionWrapper_Destroy(t *testing.T) {
-	mockSession := new(MockSession)
-	sessionWrapper := &SessionWrapper{session: mockSession}
-
-	sessionID := "session_id"
-	writeOptions := &api.WriteOptions{}
-
-	expectedMeta := &api.WriteMeta{}
-	expectedErr := errors.New("destroy error")
-
-	mockSession.On("Destroy", sessionID, writeOptions).Return(expectedMeta, expectedErr)
-
-	meta, err := sessionWrapper.Destroy(sessionID, writeOptions)
-
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockSession.AssertCalled(t, "Destroy", sessionID, writeOptions)
-}
-
-func TestSessionWrapper_Info(t *testing.T) {
-	mockSession := new(MockSession)
-	sessionWrapper := &SessionWrapper{session: mockSession}
-
-	sessionID := "session_id"
-	queryOptions := &api.QueryOptions{}
-
-	expectedEntry := &api.SessionEntry{ID: sessionID}
-	expectedMeta := &api.QueryMeta{}
-	expectedErr := errors.New("info error")
-
-	mockSession.On("Info", sessionID, queryOptions).Return(expectedEntry, expectedMeta, expectedErr)
-
-	entry, meta, err := sessionWrapper.Info(sessionID, queryOptions)
-
-	assert.Equal(t, expectedEntry, entry)
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockSession.AssertCalled(t, "Info", sessionID, queryOptions)
-}
-
-func TestKVWrapper_Put(t *testing.T) {
-	mockKV := new(MockKV)
-	kvWrapper := &KVWrapper{kv: mockKV}
-
-	kvPair := &api.KVPair{Key: "test_key", Value: []byte("test_value")}
-	writeOptions := &api.WriteOptions{}
-
-	expectedMeta := &api.WriteMeta{}
-	expectedErr := errors.New("put error")
-
-	mockKV.On("Put", kvPair, writeOptions).Return(expectedMeta, expectedErr)
-
-	meta, err := kvWrapper.Put(kvPair, writeOptions)
-
-	assert.Equal(t, expectedMeta, meta)
-	assert.Equal(t, expectedErr, err)
-	mockKV.AssertCalled(t, "Put", kvPair, writeOptions)
 }
 
 func TestRun(t *testing.T) {
@@ -2357,75 +1931,6 @@ func TestHandleServiceCriticalState_WarningState(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestConsulClientWrappers(t *testing.T) {
-	// Test consulClient wrapper methods
-	// These tests verify that the wrapper methods correctly delegate to the underlying api.Client
-	// Note: These tests use a nil api.Client because we're testing the wrapper structure,
-	// not the actual Consul API calls
-
-	t.Run("consulClient Agent returns AgentWrapper", func(t *testing.T) {
-		// Create a consul client with default config (will work even without running Consul)
-		apiClient, err := api.NewClient(api.DefaultConfig())
-		assert.NoError(t, err)
-
-		cc := &consulClient{client: apiClient}
-		agent := cc.Agent()
-		assert.NotNil(t, agent)
-
-		// Verify it returns an AgentWrapper
-		_, ok := agent.(*AgentWrapper)
-		assert.True(t, ok, "Agent() should return *AgentWrapper")
-	})
-
-	t.Run("consulClient Catalog returns CatalogWrapper", func(t *testing.T) {
-		apiClient, err := api.NewClient(api.DefaultConfig())
-		assert.NoError(t, err)
-
-		cc := &consulClient{client: apiClient}
-		catalog := cc.Catalog()
-		assert.NotNil(t, catalog)
-
-		_, ok := catalog.(*CatalogWrapper)
-		assert.True(t, ok, "Catalog() should return *CatalogWrapper")
-	})
-
-	t.Run("consulClient Health returns HealthWrapper", func(t *testing.T) {
-		apiClient, err := api.NewClient(api.DefaultConfig())
-		assert.NoError(t, err)
-
-		cc := &consulClient{client: apiClient}
-		health := cc.Health()
-		assert.NotNil(t, health)
-
-		_, ok := health.(*HealthWrapper)
-		assert.True(t, ok, "Health() should return *HealthWrapper")
-	})
-
-	t.Run("consulClient Session returns SessionWrapper", func(t *testing.T) {
-		apiClient, err := api.NewClient(api.DefaultConfig())
-		assert.NoError(t, err)
-
-		cc := &consulClient{client: apiClient}
-		session := cc.Session()
-		assert.NotNil(t, session)
-
-		_, ok := session.(*SessionWrapper)
-		assert.True(t, ok, "Session() should return *SessionWrapper")
-	})
-
-	t.Run("consulClient KV returns KVWrapper", func(t *testing.T) {
-		apiClient, err := api.NewClient(api.DefaultConfig())
-		assert.NoError(t, err)
-
-		cc := &consulClient{client: apiClient}
-		kv := cc.KV()
-		assert.NotNil(t, kv)
-
-		_, ok := kv.(*KVWrapper)
-		assert.True(t, ok, "KV() should return *KVWrapper")
-	})
-}
-
 func TestCommandExecutor(t *testing.T) {
 	t.Run("CommandContext creates exec.Cmd", func(t *testing.T) {
 		executor := &commandExecutor{}
@@ -2446,18 +1951,6 @@ func TestCommandExecutor(t *testing.T) {
 		cmd := executor.CommandContext(ctx, "true")
 		assert.NotNil(t, cmd)
 	})
-}
-
-func TestHealthWrapper_Checks(t *testing.T) {
-	// Test HealthWrapper directly with a mock Health
-	apiClient, err := api.NewClient(api.DefaultConfig())
-	assert.NoError(t, err)
-
-	hw := &HealthWrapper{health: apiClient.Health()}
-	assert.NotNil(t, hw)
-
-	// We can't actually call Checks without a running Consul,
-	// but we verify the wrapper is correctly structured
 }
 
 func TestUpdateServiceTags_WithCommandExecution(t *testing.T) {
@@ -2526,8 +2019,10 @@ func TestUpdateServiceTags_WithCommandExecution(t *testing.T) {
 		err := b.updateServiceTags(true)
 		assert.NoError(t, err)
 
-		// Give goroutine time to execute
-		time.Sleep(1500 * time.Millisecond)
+		result, ok := observeHookResult(t, b)
+		assert.True(t, ok)
+		assert.NoError(t, result.Err)
+		assert.Equal(t, HookPromote, result.Transition)
 
 		mockAgent.AssertCalled(t, "ServiceRegister", mock.Anything)
 	})
@@ -2597,8 +2092,10 @@ func TestUpdateServiceTags_WithCommandExecution(t *testing.T) {
 		err := b.updateServiceTags(false)
 		assert.NoError(t, err)
 
-		// Give goroutine time to execute
-		time.Sleep(1500 * time.Millisecond)
+		result, ok := observeHookResult(t, b)
+		assert.True(t, ok)
+		assert.NoError(t, result.Err)
+		assert.Equal(t, HookDemote, result.Transition)
 
 		mockAgent.AssertCalled(t, "ServiceRegister", mock.Anything)
 	})
@@ -2668,8 +2165,9 @@ func TestUpdateServiceTags_WithCommandExecution(t *testing.T) {
 		err := b.updateServiceTags(true)
 		assert.NoError(t, err)
 
-		// Give goroutine time to execute
-		time.Sleep(1500 * time.Millisecond)
+		result, ok := observeHookResult(t, b)
+		assert.True(t, ok)
+		assert.Error(t, result.Err)
 	})
 
 	t.Run("Handles session data retrieval error in command goroutine", func(t *testing.T) {
@@ -2724,9 +2222,17 @@ func TestUpdateServiceTags_WithCommandExecution(t *testing.T) {
 		err := b.updateServiceTags(true)
 		assert.NoError(t, err)
 
-		// Wait for goroutine to handle the error
-		time.Sleep(200 * time.Millisecond)
+		result, ok := observeHookResult(t, b)
+		assert.True(t, ok)
+		assert.ErrorContains(t, result.Err, "kv error")
 	})
+}
+
+func observeHookResult(t *testing.T, b *Ballot) (HookResult, bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return b.ObserveHookResult(ctx)
 }
 
 func TestRun_SmallTTL(t *testing.T) {
@@ -2863,53 +2369,5 @@ func TestUpdateLeadershipStatus_Error(t *testing.T) {
 		err := b.updateLeadershipStatus(true)
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
-	})
-}
-
-func TestNew_ViperUnmarshalError(t *testing.T) {
-	t.Run("New returns error when viper unmarshal fails", func(t *testing.T) {
-		viper.Reset()
-		// Set an invalid type that will cause unmarshal to fail
-		// TTL expects a duration string but we give it an invalid map
-		viper.Set("election.services.badconfig.ttl", map[string]string{"invalid": "type"})
-		viper.Set("election.services.badconfig.id", "test_id")
-		viper.Set("election.services.badconfig.key", "test/key")
-
-		defer viper.Reset()
-
-		b, err := New(context.Background(), "badconfig")
-		assert.Error(t, err)
-		assert.Nil(t, b)
-	})
-}
-
-func TestNew_DefaultValues(t *testing.T) {
-	t.Run("New sets default LockDelay and TTL when not specified", func(t *testing.T) {
-		viper.Reset()
-		viper.Set("election.services.defaults.id", "test_service_id")
-		viper.Set("election.services.defaults.key", "election/test/leader")
-		// Don't set TTL or LockDelay
-
-		defer viper.Reset()
-
-		b, err := New(context.Background(), "defaults")
-		assert.NoError(t, err)
-		assert.NotNil(t, b)
-		assert.Equal(t, 3*time.Second, b.LockDelay)
-		assert.Equal(t, 10*time.Second, b.TTL)
-	})
-
-	t.Run("New sets Name from parameter when not in config", func(t *testing.T) {
-		viper.Reset()
-		viper.Set("election.services.myservice.id", "test_service_id")
-		viper.Set("election.services.myservice.key", "election/test/leader")
-		// Don't set Name
-
-		defer viper.Reset()
-
-		b, err := New(context.Background(), "myservice")
-		assert.NoError(t, err)
-		assert.NotNil(t, b)
-		assert.Equal(t, "myservice", b.Name)
 	})
 }

--- a/internal/ballot/config.go
+++ b/internal/ballot/config.go
@@ -1,0 +1,123 @@
+package ballot
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	DefaultSessionTTL = 10 * time.Second
+	DefaultLockDelay  = 3 * time.Second
+)
+
+type LoadedConfig struct {
+	Consul   LoadedConsulConfig   `mapstructure:"consul"`
+	Election LoadedElectionConfig `mapstructure:"election"`
+}
+
+type LoadedConsulConfig struct {
+	Address string `mapstructure:"address"`
+	Token   string `mapstructure:"token"`
+}
+
+type LoadedElectionConfig struct {
+	Enabled  []string                       `mapstructure:"enabled"`
+	Services map[string]LoadedServiceConfig `mapstructure:"services"`
+}
+
+type LoadedServiceConfig struct {
+	Name          string   `mapstructure:"name"`
+	ID            string   `mapstructure:"id"`
+	Key           string   `mapstructure:"key"`
+	ServiceChecks []string `mapstructure:"serviceChecks"`
+	Token         string   `mapstructure:"token"`
+	ExecOnPromote string   `mapstructure:"execOnPromote"`
+	ExecOnDemote  string   `mapstructure:"execOnDemote"`
+	PrimaryTag    string   `mapstructure:"primaryTag"`
+	TTL           string   `mapstructure:"ttl"`
+	LockDelay     string   `mapstructure:"lockDelay"`
+}
+
+type RuntimeConfig struct {
+	Name          string
+	ID            string
+	Key           string
+	ServiceChecks []string
+	ConsulToken   string
+	ExecOnPromote string
+	ExecOnDemote  string
+	PrimaryTag    string
+	ConsulAddress string
+	TTL           time.Duration
+	LockDelay     time.Duration
+}
+
+func RuntimeConfigFor(config LoadedConfig, name string) (RuntimeConfig, error) {
+	services := config.Election.Services
+	if services == nil {
+		return RuntimeConfig{}, fmt.Errorf("service %q is not configured", name)
+	}
+
+	service, ok := services[name]
+	if !ok {
+		return RuntimeConfig{}, fmt.Errorf("service %q is not configured", name)
+	}
+
+	cfg := RuntimeConfig{
+		Name:          service.Name,
+		ID:            service.ID,
+		Key:           service.Key,
+		ServiceChecks: service.ServiceChecks,
+		ConsulToken:   config.Consul.Token,
+		ExecOnPromote: service.ExecOnPromote,
+		ExecOnDemote:  service.ExecOnDemote,
+		PrimaryTag:    service.PrimaryTag,
+		ConsulAddress: config.Consul.Address,
+		TTL:           DefaultSessionTTL,
+		LockDelay:     DefaultLockDelay,
+	}
+	if cfg.Name == "" {
+		cfg.Name = name
+	}
+	if service.Token != "" {
+		cfg.ConsulToken = service.Token
+	}
+
+	var err error
+	if service.TTL != "" {
+		cfg.TTL, err = time.ParseDuration(service.TTL)
+		if err != nil {
+			return RuntimeConfig{}, fmt.Errorf("ttl for service %q is invalid: %w", name, err)
+		}
+	}
+	if service.LockDelay != "" {
+		cfg.LockDelay, err = time.ParseDuration(service.LockDelay)
+		if err != nil {
+			return RuntimeConfig{}, fmt.Errorf("lockDelay for service %q is invalid: %w", name, err)
+		}
+	}
+
+	if err := validateRuntimeConfig(cfg); err != nil {
+		return RuntimeConfig{}, err
+	}
+	return cfg, nil
+}
+
+func validateRuntimeConfig(cfg RuntimeConfig) error {
+	if cfg.ID == "" {
+		return fmt.Errorf("service ID is required; please set the 'id' field in the configuration")
+	}
+	if cfg.Key == "" {
+		return fmt.Errorf("key is required; please set the 'key' field in the configuration")
+	}
+	if cfg.Name == "" {
+		return fmt.Errorf("service name is required")
+	}
+	if cfg.TTL == 0 {
+		return fmt.Errorf("ttl is required")
+	}
+	if cfg.LockDelay == 0 {
+		return fmt.Errorf("lockDelay is required")
+	}
+	return nil
+}

--- a/internal/ballot/config_test.go
+++ b/internal/ballot/config_test.go
@@ -1,0 +1,110 @@
+package ballot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeConfigFor(t *testing.T) {
+	t.Run("named service", func(t *testing.T) {
+		cfg, err := RuntimeConfigFor(LoadedConfig{
+			Consul: LoadedConsulConfig{
+				Address: "127.0.0.1:8500",
+				Token:   "global-token",
+			},
+			Election: LoadedElectionConfig{
+				Services: map[string]LoadedServiceConfig{
+					"my-service": {
+						Name:          "service-name",
+						ID:            "service-id",
+						Key:           "election/service/leader",
+						ServiceChecks: []string{"service:service-id"},
+						Token:         "service-token",
+						PrimaryTag:    "primary",
+						ExecOnPromote: "echo promoted",
+						ExecOnDemote:  "echo demoted",
+						TTL:           "15s",
+						LockDelay:     "5s",
+					},
+				},
+			},
+		}, "my-service")
+
+		require.NoError(t, err)
+		assert.Equal(t, "service-name", cfg.Name)
+		assert.Equal(t, "service-id", cfg.ID)
+		assert.Equal(t, "election/service/leader", cfg.Key)
+		assert.Equal(t, []string{"service:service-id"}, cfg.ServiceChecks)
+		assert.Equal(t, "service-token", cfg.ConsulToken)
+		assert.Equal(t, "127.0.0.1:8500", cfg.ConsulAddress)
+		assert.Equal(t, "primary", cfg.PrimaryTag)
+		assert.Equal(t, "echo promoted", cfg.ExecOnPromote)
+		assert.Equal(t, "echo demoted", cfg.ExecOnDemote)
+		assert.Equal(t, 15*time.Second, cfg.TTL)
+		assert.Equal(t, 5*time.Second, cfg.LockDelay)
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		cfg, err := RuntimeConfigFor(LoadedConfig{
+			Election: LoadedElectionConfig{
+				Services: map[string]LoadedServiceConfig{
+					"my-service": {
+						ID:  "service-id",
+						Key: "election/service/leader",
+					},
+				},
+			},
+		}, "my-service")
+
+		require.NoError(t, err)
+		assert.Equal(t, "my-service", cfg.Name)
+		assert.Equal(t, DefaultSessionTTL, cfg.TTL)
+		assert.Equal(t, DefaultLockDelay, cfg.LockDelay)
+	})
+
+	t.Run("missing service ID", func(t *testing.T) {
+		_, err := RuntimeConfigFor(LoadedConfig{
+			Election: LoadedElectionConfig{
+				Services: map[string]LoadedServiceConfig{
+					"my-service": {Key: "election/service/leader"},
+				},
+			},
+		}, "my-service")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service ID is required")
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		_, err := RuntimeConfigFor(LoadedConfig{
+			Election: LoadedElectionConfig{
+				Services: map[string]LoadedServiceConfig{
+					"my-service": {ID: "service-id"},
+				},
+			},
+		}, "my-service")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key is required")
+	})
+
+	t.Run("malformed duration", func(t *testing.T) {
+		_, err := RuntimeConfigFor(LoadedConfig{
+			Election: LoadedElectionConfig{
+				Services: map[string]LoadedServiceConfig{
+					"my-service": {
+						ID:  "service-id",
+						Key: "election/service/leader",
+						TTL: "definitely-not-a-duration",
+					},
+				},
+			},
+		}, "my-service")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ttl")
+	})
+}

--- a/internal/ballot/consul_interaction.go
+++ b/internal/ballot/consul_interaction.go
@@ -1,0 +1,211 @@
+package ballot
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/consul/api"
+	log "github.com/sirupsen/logrus"
+)
+
+type ConsulElectionInteraction struct {
+	client ConsulClient
+	cfg    RuntimeConfig
+}
+
+func NewConsulElectionInteraction(client ConsulClient, cfg RuntimeConfig) *ConsulElectionInteraction {
+	return &ConsulElectionInteraction{client: client, cfg: cfg}
+}
+
+func (i *ConsulElectionInteraction) LocalService() (*api.AgentService, []*api.CatalogService, error) {
+	if i.cfg.ID == "" {
+		return nil, nil, fmt.Errorf("service ID is empty; please ensure it is set in the configuration")
+	}
+	service, _, err := i.client.Agent().Service(i.cfg.ID, &api.QueryOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	if service == nil {
+		return nil, nil, fmt.Errorf("service %s not found", i.cfg.ID)
+	}
+	catalogServices, _, err := i.client.Catalog().Service(i.cfg.Name, i.cfg.PrimaryTag, &api.QueryOptions{})
+	if err != nil {
+		return service, nil, err
+	}
+	return service, catalogServices, nil
+}
+
+func (i *ConsulElectionInteraction) HealthState() (string, error) {
+	healthChecks, _, err := i.client.Health().Checks(i.cfg.Name, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get health checks: %w", err)
+	}
+
+	state := "passing"
+	for _, check := range healthChecks {
+		if check.ServiceID != i.cfg.ID {
+			continue
+		}
+		if len(i.cfg.ServiceChecks) > 0 && !slices.Contains(i.cfg.ServiceChecks, check.CheckID) {
+			continue
+		}
+		if check.Status == "critical" {
+			return "critical", nil
+		}
+		if check.Status == "warning" {
+			state = "warning"
+		}
+	}
+	return state, nil
+}
+
+func (i *ConsulElectionInteraction) AcquireLeadership(payload *ElectionPayload, sessionID string) (bool, *api.WriteMeta, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to marshal election payload: %w", err)
+	}
+
+	content := &api.KVPair{
+		Key:     i.cfg.Key,
+		Session: sessionID,
+		Value:   data,
+	}
+
+	acquired, meta, err := i.client.KV().Acquire(content, nil)
+	if err != nil {
+		return false, meta, err
+	}
+	return acquired, meta, nil
+}
+
+func (i *ConsulElectionInteraction) LockPayload() (*ElectionPayload, error) {
+	sessionKey, _, err := i.client.KV().Get(i.cfg.Key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if sessionKey == nil {
+		return nil, nil
+	}
+	var data *ElectionPayload
+	if err := json.Unmarshal(sessionKey.Value, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (i *ConsulElectionInteraction) ApplyPrimaryTag(isLeader bool) (bool, error) {
+	service, _, err := i.LocalService()
+	if err != nil {
+		return false, err
+	}
+
+	registration := copyServiceToRegistration(service)
+	if registration == nil {
+		return false, fmt.Errorf("service registration is nil")
+	}
+
+	hasPrimaryTag := slices.Contains(registration.Tags, i.cfg.PrimaryTag)
+	if isLeader && !hasPrimaryTag {
+		registration.Tags = append(slices.Clone(registration.Tags), i.cfg.PrimaryTag)
+	} else if !isLeader && hasPrimaryTag {
+		index := slices.Index(registration.Tags, i.cfg.PrimaryTag)
+		registration.Tags = slices.Delete(slices.Clone(registration.Tags), index, index+1)
+	} else {
+		return false, nil
+	}
+
+	log.WithFields(log.Fields{
+		"caller":  "updateServiceTags",
+		"service": i.cfg.ID,
+		"tags":    registration.Tags,
+	}).Debug("Updated service tags")
+
+	return true, i.client.Agent().ServiceRegister(registration)
+}
+
+func (i *ConsulElectionInteraction) CleanupStalePrimaryTags(payload *ElectionPayload, isLeader bool) error {
+	if !isLeader {
+		return nil
+	}
+
+	catalogServices, _, err := i.client.Catalog().Service(i.cfg.Name, "", nil)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve services from the catalog: %s", err)
+	}
+
+	for _, service := range catalogServices {
+		if service.ServiceAddress == payload.Address && service.ServicePort == payload.Port {
+			continue
+		}
+
+		primaryTagIndex := slices.Index(service.ServiceTags, i.cfg.PrimaryTag)
+		if primaryTagIndex == -1 {
+			continue
+		}
+
+		updatedTags := slices.Delete(slices.Clone(service.ServiceTags), primaryTagIndex, primaryTagIndex+1)
+		catalogRegistration := copyCatalogServiceToRegistration(service)
+		if catalogRegistration == nil || catalogRegistration.Service == nil {
+			continue
+		}
+		catalogRegistration.Service.Tags = updatedTags
+
+		_, err := i.client.Catalog().Register(catalogRegistration, nil)
+		if err != nil {
+			return fmt.Errorf("failed to update service tags in the catalog: %s", err)
+		}
+
+		log.WithFields(log.Fields{
+			"caller":  "cleanup",
+			"service": service.ServiceID,
+			"node":    service.Node,
+			"tags":    updatedTags,
+		}).Info("Cleaned up primary tag from service")
+	}
+	return nil
+}
+
+func copyServiceToRegistration(service *api.AgentService) *api.AgentServiceRegistration {
+	if service == nil {
+		return nil
+	}
+	return &api.AgentServiceRegistration{
+		ID:      service.ID,
+		Name:    service.Service,
+		Tags:    service.Tags,
+		Port:    service.Port,
+		Address: service.Address,
+		Kind:    service.Kind,
+		Weights: &service.Weights,
+		Meta:    service.Meta,
+	}
+}
+
+func copyCatalogServiceToRegistration(service *api.CatalogService) *api.CatalogRegistration {
+	if service == nil {
+		return nil
+	}
+	return &api.CatalogRegistration{
+		ID:              service.ID,
+		Node:            service.Node,
+		Address:         service.ServiceAddress,
+		TaggedAddresses: service.TaggedAddresses,
+		NodeMeta:        service.NodeMeta,
+		Datacenter:      service.Datacenter,
+		Service: &api.AgentService{
+			ID:              service.ServiceID,
+			Service:         service.ServiceName,
+			Tags:            service.ServiceTags,
+			Meta:            service.ServiceMeta,
+			Port:            service.ServicePort,
+			Address:         service.ServiceAddress,
+			TaggedAddresses: service.ServiceTaggedAddresses,
+			Weights: api.AgentWeights{
+				Passing: service.ServiceWeights.Passing,
+				Warning: service.ServiceWeights.Warning,
+			},
+			EnableTagOverride: service.ServiceEnableTagOverride,
+		},
+	}
+}

--- a/internal/ballot/election_step.go
+++ b/internal/ballot/election_step.go
@@ -1,0 +1,96 @@
+package ballot
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type ElectionStepStatus string
+
+const (
+	ElectionStepLeader         ElectionStepStatus = "leader"
+	ElectionStepFollower       ElectionStepStatus = "follower"
+	ElectionStepCriticalHealth ElectionStepStatus = "critical_health"
+	ElectionStepServiceFailure ElectionStepStatus = "service_failure"
+	ElectionStepSessionFailure ElectionStepStatus = "session_failure"
+	ElectionStepLockFailure    ElectionStepStatus = "lock_failure"
+	ElectionStepCleanupFailure ElectionStepStatus = "cleanup_failure"
+	ElectionStepPayloadFailure ElectionStepStatus = "payload_failure"
+)
+
+type ElectionStepResult struct {
+	Status ElectionStepStatus
+	Err    error
+	Leader bool
+}
+
+type ElectionStep struct {
+	ballot *Ballot
+}
+
+func NewElectionStep(ballot *Ballot) *ElectionStep {
+	return &ElectionStep{ballot: ballot}
+}
+
+func (s *ElectionStep) Run() ElectionStepResult {
+	b := s.ballot
+	if err := b.handleServiceCriticalState(); err != nil {
+		return ElectionStepResult{Status: ElectionStepCriticalHealth, Err: err, Leader: false}
+	}
+
+	service, _, err := b.getService()
+	if err != nil {
+		return ElectionStepResult{
+			Status: ElectionStepServiceFailure,
+			Err:    fmt.Errorf("failed to get service: %w", err),
+		}
+	}
+
+	if err := b.session(); err != nil {
+		return ElectionStepResult{
+			Status: ElectionStepSessionFailure,
+			Err:    fmt.Errorf("failed to create session: %w", err),
+		}
+	}
+
+	sessionIDPtr, ok := b.getSessionID()
+	if !ok || sessionIDPtr == nil {
+		return ElectionStepResult{Status: ElectionStepSessionFailure, Err: fmt.Errorf("session ID is nil")}
+	}
+	electionPayload := &ElectionPayload{
+		Address:   service.Address,
+		Port:      service.Port,
+		SessionID: *sessionIDPtr,
+	}
+
+	if !b.leader.Load() {
+		acquired, _, err := b.attemptLeadershipAcquisition(electionPayload)
+		if err != nil {
+			return ElectionStepResult{
+				Status: ElectionStepLockFailure,
+				Err:    fmt.Errorf("failed to acquire lock: %w", err),
+			}
+		}
+		if acquired {
+			log.WithFields(log.Fields{
+				"caller": "election",
+			}).Info("Acquired leadership")
+		}
+	}
+
+	if err := b.verifyAndUpdateLeadershipStatus(); err != nil {
+		return ElectionStepResult{Status: ElectionStepPayloadFailure, Err: err, Leader: b.IsLeader()}
+	}
+	if err := b.cleanup(electionPayload); err != nil {
+		return ElectionStepResult{
+			Status: ElectionStepCleanupFailure,
+			Err:    fmt.Errorf("failed to cleanup: %w", err),
+			Leader: b.IsLeader(),
+		}
+	}
+	if b.IsLeader() {
+		return ElectionStepResult{Status: ElectionStepLeader, Leader: true}
+	}
+	return ElectionStepResult{Status: ElectionStepFollower, Leader: false}
+}

--- a/internal/ballot/election_step_test.go
+++ b/internal/ballot/election_step_test.go
@@ -1,0 +1,257 @@
+package ballot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestElectionStep_Run_successfulTransition(t *testing.T) {
+	b := stepTestBallot(context.Background())
+	sessionID := "session-id"
+	payload := &ElectionPayload{Address: "127.0.0.1", Port: 8080, SessionID: sessionID}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	mockHealth := new(MockHealth)
+	mockHealth.On("Checks", b.Name, (*api.QueryOptions)(nil)).Return(api.HealthChecks{
+		{ServiceID: b.ID, CheckID: "check1", Status: "passing"},
+	}, nil, nil)
+
+	service := &api.AgentService{ID: b.ID, Service: b.Name, Address: payload.Address, Port: payload.Port, Tags: []string{"blue"}}
+	mockAgent := new(MockAgent)
+	mockAgent.On("Service", b.ID, mock.Anything).Return(service, nil, nil)
+	mockAgent.On("ServiceRegister", mock.MatchedBy(func(reg *api.AgentServiceRegistration) bool {
+		return assert.ObjectsAreEqual([]string{"blue", "primary"}, reg.Tags)
+	})).Return(nil)
+
+	staleService := &api.CatalogService{
+		ID:             "catalog-id",
+		Node:           "node-1",
+		ServiceID:      "stale-service",
+		ServiceName:    b.Name,
+		ServiceAddress: "127.0.0.2",
+		ServicePort:    8081,
+		ServiceTags:    []string{"primary", "blue"},
+	}
+	mockCatalog := new(MockCatalog)
+	mockCatalog.On("Service", b.Name, b.PrimaryTag, mock.Anything).Return([]*api.CatalogService{}, nil, nil)
+	mockCatalog.On("Service", b.Name, "", (*api.QueryOptions)(nil)).Return([]*api.CatalogService{staleService}, nil, nil)
+	mockCatalog.On("Register", mock.MatchedBy(func(reg *api.CatalogRegistration) bool {
+		return reg.Service != nil && assert.ObjectsAreEqual([]string{"blue"}, reg.Service.Tags)
+	}), (*api.WriteOptions)(nil)).Return(&api.WriteMeta{}, nil)
+
+	mockSession := new(MockSession)
+	mockSession.On("Create", mock.Anything, (*api.WriteOptions)(nil)).Return(sessionID, nil, nil)
+	mockSession.On("RenewPeriodic", "10s", sessionID, (*api.WriteOptions)(nil), mock.Anything).Return(nil)
+
+	mockKV := new(MockKV)
+	mockKV.On("Acquire", mock.Anything, (*api.WriteOptions)(nil)).Return(true, nil, nil)
+	mockKV.On("Get", b.Key, (*api.QueryOptions)(nil)).Return(&api.KVPair{Key: b.Key, Value: data, Session: sessionID}, nil, nil)
+
+	mockClient := &MockConsulClient{}
+	mockClient.On("Health").Return(mockHealth)
+	mockClient.On("Agent").Return(mockAgent)
+	mockClient.On("Catalog").Return(mockCatalog)
+	mockClient.On("Session").Return(mockSession)
+	mockClient.On("KV").Return(mockKV)
+	b.client = mockClient
+
+	result := NewElectionStep(b).Run()
+
+	require.NoError(t, result.Err)
+	assert.Equal(t, ElectionStepLeader, result.Status)
+	assert.True(t, result.Leader)
+	assert.True(t, b.IsLeader())
+	mockAgent.AssertCalled(t, "ServiceRegister", mock.Anything)
+	mockCatalog.AssertCalled(t, "Register", mock.Anything, (*api.WriteOptions)(nil))
+}
+
+func TestElectionStep_Run_failures(t *testing.T) {
+	t.Run("critical health", func(t *testing.T) {
+		b := stepTestBallot(context.Background())
+		mockHealth := new(MockHealth)
+		mockHealth.On("Checks", b.Name, (*api.QueryOptions)(nil)).Return(api.HealthChecks{
+			{ServiceID: b.ID, CheckID: "check1", Status: "critical"},
+		}, nil, nil)
+		mockAgent := new(MockAgent)
+		mockAgent.On("Service", b.ID, mock.Anything).Return(&api.AgentService{ID: b.ID, Service: b.Name, Tags: []string{"primary"}}, nil, nil)
+		mockAgent.On("ServiceRegister", mock.Anything).Return(nil)
+		mockCatalog := new(MockCatalog)
+		mockCatalog.On("Service", b.Name, b.PrimaryTag, mock.Anything).Return([]*api.CatalogService{}, nil, nil)
+		mockClient := &MockConsulClient{}
+		mockClient.On("Health").Return(mockHealth)
+		mockClient.On("Agent").Return(mockAgent)
+		mockClient.On("Catalog").Return(mockCatalog)
+		b.client = mockClient
+
+		result := NewElectionStep(b).Run()
+
+		require.Error(t, result.Err)
+		assert.Equal(t, ElectionStepCriticalHealth, result.Status)
+	})
+
+	t.Run("missing service", func(t *testing.T) {
+		b := stepTestBallot(context.Background())
+		mockHealth := new(MockHealth)
+		mockHealth.On("Checks", b.Name, (*api.QueryOptions)(nil)).Return(api.HealthChecks{
+			{ServiceID: b.ID, CheckID: "check1", Status: "passing"},
+		}, nil, nil)
+		mockAgent := new(MockAgent)
+		mockAgent.On("Service", b.ID, mock.Anything).Return((*api.AgentService)(nil), nil, nil)
+		mockClient := &MockConsulClient{}
+		mockClient.On("Health").Return(mockHealth)
+		mockClient.On("Agent").Return(mockAgent)
+		b.client = mockClient
+
+		result := NewElectionStep(b).Run()
+
+		require.Error(t, result.Err)
+		assert.Equal(t, ElectionStepServiceFailure, result.Status)
+	})
+
+	t.Run("session failure", func(t *testing.T) {
+		b := stepTestBallot(context.Background())
+		withPassingHealthAndService(b)
+		mockSession := new(MockSession)
+		mockSession.On("Create", mock.Anything, (*api.WriteOptions)(nil)).Return("", nil, errors.New("create failed"))
+		b.client.(*MockConsulClient).On("Session").Return(mockSession)
+
+		result := NewElectionStep(b).Run()
+
+		require.Error(t, result.Err)
+		assert.Equal(t, ElectionStepSessionFailure, result.Status)
+	})
+
+	t.Run("lock failure", func(t *testing.T) {
+		b := stepTestBallot(context.Background())
+		withPassingHealthAndService(b)
+		sessionID := "session-id"
+		mockSession := new(MockSession)
+		mockSession.On("Create", mock.Anything, (*api.WriteOptions)(nil)).Return(sessionID, nil, nil)
+		mockSession.On("RenewPeriodic", "10s", sessionID, (*api.WriteOptions)(nil), mock.Anything).Return(nil)
+		mockKV := new(MockKV)
+		mockKV.On("Acquire", mock.Anything, (*api.WriteOptions)(nil)).Return(false, nil, errors.New("lock failed"))
+		b.client.(*MockConsulClient).On("Session").Return(mockSession)
+		b.client.(*MockConsulClient).On("KV").Return(mockKV)
+
+		result := NewElectionStep(b).Run()
+
+		require.Error(t, result.Err)
+		assert.Equal(t, ElectionStepLockFailure, result.Status)
+	})
+
+	t.Run("invalid lock payload", func(t *testing.T) {
+		b := stepTestBallot(context.Background())
+		withPassingHealthAndService(b)
+		sessionID := "session-id"
+		mockSession := new(MockSession)
+		mockSession.On("Create", mock.Anything, (*api.WriteOptions)(nil)).Return(sessionID, nil, nil)
+		mockSession.On("RenewPeriodic", "10s", sessionID, (*api.WriteOptions)(nil), mock.Anything).Return(nil)
+		mockKV := new(MockKV)
+		mockKV.On("Acquire", mock.Anything, (*api.WriteOptions)(nil)).Return(true, nil, nil)
+		mockKV.On("Get", b.Key, (*api.QueryOptions)(nil)).Return(&api.KVPair{Key: b.Key, Value: []byte("{")}, nil, nil)
+		b.client.(*MockConsulClient).On("Session").Return(mockSession)
+		b.client.(*MockConsulClient).On("KV").Return(mockKV)
+
+		result := NewElectionStep(b).Run()
+
+		require.Error(t, result.Err)
+		assert.Equal(t, ElectionStepPayloadFailure, result.Status)
+	})
+
+	t.Run("cleanup failure", func(t *testing.T) {
+		b := stepTestBallot(context.Background())
+		sessionID := "session-id"
+		payload := &ElectionPayload{Address: "127.0.0.1", Port: 8080, SessionID: sessionID}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+		mockHealth := new(MockHealth)
+		mockHealth.On("Checks", b.Name, (*api.QueryOptions)(nil)).Return(api.HealthChecks{
+			{ServiceID: b.ID, CheckID: "check1", Status: "passing"},
+		}, nil, nil)
+		mockAgent := new(MockAgent)
+		mockAgent.On("Service", b.ID, mock.Anything).Return(&api.AgentService{
+			ID:      b.ID,
+			Service: b.Name,
+			Address: "127.0.0.1",
+			Port:    8080,
+			Tags:    []string{},
+		}, nil, nil)
+		mockAgent.On("ServiceRegister", mock.Anything).Return(nil)
+		mockSession := new(MockSession)
+		mockSession.On("Create", mock.Anything, (*api.WriteOptions)(nil)).Return(sessionID, nil, nil)
+		mockSession.On("RenewPeriodic", "10s", sessionID, (*api.WriteOptions)(nil), mock.Anything).Return(nil)
+		mockKV := new(MockKV)
+		mockKV.On("Acquire", mock.Anything, (*api.WriteOptions)(nil)).Return(true, nil, nil)
+		mockKV.On("Get", b.Key, (*api.QueryOptions)(nil)).Return(&api.KVPair{Key: b.Key, Value: data}, nil, nil)
+		mockClient := &MockConsulClient{}
+		mockClient.On("Health").Return(mockHealth)
+		mockClient.On("Agent").Return(mockAgent)
+		mockClient.On("Catalog").Return(&cleanupFailingCatalog{MockCatalog: new(MockCatalog), serviceName: b.Name})
+		mockClient.On("Session").Return(mockSession)
+		mockClient.On("KV").Return(mockKV)
+		b.client = mockClient
+
+		result := NewElectionStep(b).Run()
+
+		require.Error(t, result.Err)
+		assert.Equal(t, ElectionStepCleanupFailure, result.Status)
+	})
+}
+
+func stepTestBallot(ctx context.Context) *Ballot {
+	return &Ballot{
+		ID:            "test_service_id",
+		Name:          "test_service",
+		Key:           "election/test_service/leader",
+		PrimaryTag:    "primary",
+		ServiceChecks: []string{"check1"},
+		TTL:           10 * time.Second,
+		LockDelay:     3 * time.Second,
+		ctx:           ctx,
+	}
+}
+
+func withPassingHealthAndService(b *Ballot) {
+	mockHealth := new(MockHealth)
+	mockHealth.On("Checks", b.Name, (*api.QueryOptions)(nil)).Return(api.HealthChecks{
+		{ServiceID: b.ID, CheckID: "check1", Status: "passing"},
+	}, nil, nil)
+	mockAgent := new(MockAgent)
+	mockAgent.On("Service", b.ID, mock.Anything).Return(&api.AgentService{
+		ID:      b.ID,
+		Service: b.Name,
+		Address: "127.0.0.1",
+		Port:    8080,
+		Tags:    []string{},
+	}, nil, nil)
+	mockAgent.On("ServiceRegister", mock.Anything).Return(nil)
+	mockCatalog := new(MockCatalog)
+	mockCatalog.On("Service", b.Name, b.PrimaryTag, mock.Anything).Return([]*api.CatalogService{}, nil, nil)
+	mockCatalog.On("Service", b.Name, "", (*api.QueryOptions)(nil)).Return([]*api.CatalogService{}, nil, nil)
+	mockClient := &MockConsulClient{}
+	mockClient.On("Health").Return(mockHealth)
+	mockClient.On("Agent").Return(mockAgent)
+	mockClient.On("Catalog").Return(mockCatalog)
+	b.client = mockClient
+}
+
+type cleanupFailingCatalog struct {
+	*MockCatalog
+	serviceName string
+}
+
+func (c *cleanupFailingCatalog) Service(serviceName, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error) {
+	if serviceName == c.serviceName && tag == "" {
+		return nil, nil, errors.New("cleanup failed")
+	}
+	return []*api.CatalogService{}, nil, nil
+}

--- a/internal/ballot/hooks.go
+++ b/internal/ballot/hooks.go
@@ -1,0 +1,96 @@
+package ballot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/shlex"
+)
+
+type HookTransition string
+
+const (
+	HookPromote HookTransition = "promote"
+	HookDemote  HookTransition = "demote"
+)
+
+type HookRequest struct {
+	Transition HookTransition
+	Command    string
+	Payload    *ElectionPayload
+	Timeout    time.Duration
+}
+
+type HookResult struct {
+	Transition HookTransition
+	Command    string
+	Output     []byte
+	Err        error
+	TimedOut   bool
+	Skipped    bool
+}
+
+type LeadershipHooks struct {
+	executor CommandExecutor
+}
+
+func NewLeadershipHooks(executor CommandExecutor) *LeadershipHooks {
+	if executor == nil {
+		executor = &commandExecutor{}
+	}
+	return &LeadershipHooks{executor: executor}
+}
+
+func (h *LeadershipHooks) Execute(ctx context.Context, req HookRequest) HookResult {
+	result := HookResult{
+		Transition: req.Transition,
+		Command:    req.Command,
+	}
+	if strings.TrimSpace(req.Command) == "" {
+		result.Skipped = true
+		return result
+	}
+	if req.Payload == nil {
+		result.Err = fmt.Errorf("hook payload is required")
+		return result
+	}
+
+	args, err := shlex.Split(req.Command)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	if len(args) == 0 {
+		result.Err = fmt.Errorf("empty command")
+		return result
+	}
+
+	commandCtx := ctx
+	cancel := func() {}
+	if req.Timeout > 0 {
+		commandCtx, cancel = context.WithTimeout(ctx, req.Timeout)
+	}
+	defer cancel()
+
+	cmd := h.executor.CommandContext(commandCtx, args[0], args[1:]...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("ADDRESS=%s", req.Payload.Address),
+		fmt.Sprintf("PORT=%d", req.Payload.Port),
+		fmt.Sprintf("SESSIONID=%s", req.Payload.SessionID),
+	)
+
+	result.Output, result.Err = cmd.CombinedOutput()
+	result.TimedOut = commandCtx.Err() == context.DeadlineExceeded
+	return result
+}
+
+func HookTimeout(ttl, lockDelay time.Duration) time.Duration {
+	timeout := (ttl + lockDelay) * 2
+	if timeout <= 0 {
+		return DefaultSessionTTL
+	}
+	return timeout
+}

--- a/internal/ballot/hooks_test.go
+++ b/internal/ballot/hooks_test.go
@@ -1,0 +1,132 @@
+package ballot
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeadershipHooks_Execute(t *testing.T) {
+	payload := &ElectionPayload{
+		Address:   "127.0.0.1",
+		Port:      8080,
+		SessionID: "abc123",
+	}
+
+	t.Run("promotion hook completes with environment", func(t *testing.T) {
+		hooks := NewLeadershipHooks(&commandExecutor{})
+
+		result := hooks.Execute(context.Background(), HookRequest{
+			Transition: HookPromote,
+			Command:    `sh -c 'printf "%s:%s:%s" "$ADDRESS" "$PORT" "$SESSIONID"'`,
+			Payload:    payload,
+			Timeout:    time.Second,
+		})
+
+		require.NoError(t, result.Err)
+		assert.Equal(t, HookPromote, result.Transition)
+		assert.Equal(t, "127.0.0.1:8080:abc123", string(result.Output))
+		assert.False(t, result.TimedOut)
+	})
+
+	t.Run("demotion hook completes", func(t *testing.T) {
+		hooks := NewLeadershipHooks(&commandExecutor{})
+
+		result := hooks.Execute(context.Background(), HookRequest{
+			Transition: HookDemote,
+			Command:    `sh -c 'printf demoted'`,
+			Payload:    payload,
+			Timeout:    time.Second,
+		})
+
+		require.NoError(t, result.Err)
+		assert.Equal(t, HookDemote, result.Transition)
+		assert.Equal(t, "demoted", string(result.Output))
+	})
+
+	t.Run("command failure is observable", func(t *testing.T) {
+		hooks := NewLeadershipHooks(&commandExecutor{})
+
+		result := hooks.Execute(context.Background(), HookRequest{
+			Command: `sh -c 'exit 7'`,
+			Payload: payload,
+			Timeout: time.Second,
+		})
+
+		require.Error(t, result.Err)
+		assert.False(t, result.TimedOut)
+	})
+
+	t.Run("timeout is observable", func(t *testing.T) {
+		hooks := NewLeadershipHooks(&commandExecutor{})
+
+		result := hooks.Execute(context.Background(), HookRequest{
+			Command: `sh -c 'sleep 1'`,
+			Payload: payload,
+			Timeout: 10 * time.Millisecond,
+		})
+
+		require.Error(t, result.Err)
+		assert.True(t, result.TimedOut)
+	})
+
+	t.Run("no hook configured", func(t *testing.T) {
+		hooks := NewLeadershipHooks(&commandExecutor{})
+
+		result := hooks.Execute(context.Background(), HookRequest{Payload: payload})
+
+		assert.NoError(t, result.Err)
+		assert.True(t, result.Skipped)
+	})
+}
+
+func TestBallot_ObserveHookResult(t *testing.T) {
+	t.Run("observes published result", func(t *testing.T) {
+		b := &Ballot{}
+		expected := HookResult{Transition: HookPromote, Command: "echo promoted", Output: []byte("promoted\n")}
+
+		b.publishHookResult(expected)
+		result, ok := observeHookResult(t, b)
+
+		require.True(t, ok)
+		assert.Equal(t, expected.Transition, result.Transition)
+		assert.Equal(t, expected.Command, result.Command)
+		assert.Equal(t, expected.Output, result.Output)
+	})
+
+	t.Run("returns false when context is cancelled", func(t *testing.T) {
+		b := &Ballot{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		result, ok := b.ObserveHookResult(ctx)
+
+		assert.False(t, ok)
+		assert.ErrorIs(t, result.Err, context.Canceled)
+	})
+
+	t.Run("concurrent publish and observe share one channel", func(t *testing.T) {
+		b := &Ballot{}
+		const count = 8
+
+		var publishers sync.WaitGroup
+		for i := 0; i < count; i++ {
+			publishers.Add(1)
+			go func() {
+				defer publishers.Done()
+				b.publishHookResult(HookResult{Transition: HookPromote})
+			}()
+		}
+		publishers.Wait()
+
+		for i := 0; i < count; i++ {
+			result, ok := observeHookResult(t, b)
+			require.True(t, ok)
+			assert.Equal(t, HookPromote, result.Transition)
+		}
+	})
+}

--- a/internal/ballot/session_lifecycle.go
+++ b/internal/ballot/session_lifecycle.go
@@ -1,0 +1,178 @@
+package ballot
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	log "github.com/sirupsen/logrus"
+)
+
+type SessionEventType string
+
+const (
+	SessionCreated       SessionEventType = "created"
+	SessionRenewalFailed SessionEventType = "renewal_failed"
+	SessionCancelled     SessionEventType = "cancelled"
+	SessionReleased      SessionEventType = "released"
+)
+
+type SessionEvent struct {
+	Type      SessionEventType
+	SessionID string
+	Err       error
+}
+
+type SessionLifecycle struct {
+	ctx         context.Context
+	session     SessionInterface
+	sessionID   *atomic.Value
+	checks      []string
+	ttl         string
+	lockDelay   time.Duration
+	cancelMu    sync.Mutex
+	renewCancel context.CancelFunc
+	events      chan SessionEvent
+}
+
+func NewSessionLifecycle(ctx context.Context, session SessionInterface, sessionID *atomic.Value, cfg RuntimeConfig) *SessionLifecycle {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &SessionLifecycle{
+		ctx:       ctx,
+		session:   session,
+		sessionID: sessionID,
+		checks:    slices.Clone(cfg.ServiceChecks),
+		ttl:       cfg.TTL.String(),
+		lockDelay: cfg.LockDelay,
+		events:    make(chan SessionEvent, 8),
+	}
+}
+
+func (sl *SessionLifecycle) ActiveSession() (string, error) {
+	if sl.session == nil {
+		return "", fmt.Errorf("consul client is required")
+	}
+	if current, ok := sl.currentSessionID(); ok && current != "" {
+		sessionInfo, _, err := sl.session.Info(current, nil)
+		if err != nil {
+			return "", err
+		}
+		if sessionInfo != nil {
+			log.WithFields(log.Fields{
+				"caller":  "session",
+				"session": current,
+			}).Trace("Returning cached session")
+			return current, nil
+		}
+		sl.cancelRenewal(SessionCancelled, current, nil)
+	}
+
+	log.WithFields(log.Fields{
+		"caller": "session",
+	}).Trace("Creating new session")
+	sessionID, _, err := sl.session.Create(&api.SessionEntry{
+		Behavior:  "delete",
+		Checks:    append(slices.Clone(sl.checks), "serfHealth"),
+		TTL:       sl.ttl,
+		LockDelay: sl.lockDelay,
+	}, nil)
+	if err != nil {
+		return "", err
+	}
+
+	log.WithFields(log.Fields{
+		"caller": "session",
+		"ID":     sessionID,
+	}).Trace("Storing session ID")
+	sl.sessionID.Store(&sessionID)
+	sl.publish(SessionEvent{Type: SessionCreated, SessionID: sessionID})
+	sl.startRenewal(sessionID)
+	return sessionID, nil
+}
+
+func (sl *SessionLifecycle) Release() error {
+	sessionIDPtr, ok := sl.getSessionID()
+	if !ok || sessionIDPtr == nil {
+		return nil
+	}
+	sessionID := *sessionIDPtr
+	sl.sessionID.Store((*string)(nil))
+	sl.cancelRenewal(SessionReleased, sessionID, nil)
+	_, err := sl.session.Destroy(sessionID, nil)
+	return err
+}
+
+func (sl *SessionLifecycle) Events() <-chan SessionEvent {
+	return sl.events
+}
+
+func (sl *SessionLifecycle) getSessionID() (*string, bool) {
+	sessionIDValue := sl.sessionID.Load()
+	if sessionIDValue == nil {
+		return nil, false
+	}
+	sessionIDPtr, ok := sessionIDValue.(*string)
+	return sessionIDPtr, ok
+}
+
+func (sl *SessionLifecycle) currentSessionID() (string, bool) {
+	sessionIDPtr, ok := sl.getSessionID()
+	if !ok || sessionIDPtr == nil {
+		return "", false
+	}
+	return *sessionIDPtr, true
+}
+
+func (sl *SessionLifecycle) startRenewal(sessionID string) {
+	sl.cancelRenewal(SessionCancelled, sessionID, nil)
+
+	renewCtx, renewCancel := context.WithCancel(sl.ctx)
+	sl.cancelMu.Lock()
+	sl.renewCancel = renewCancel
+	sl.cancelMu.Unlock()
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.WithFields(log.Fields{
+					"caller": "session",
+					"error":  r,
+				}).Error("Recovered from panic in session renewal")
+			}
+		}()
+
+		err := sl.session.RenewPeriodic(sl.ttl, sessionID, nil, renewCtx.Done())
+		if err != nil {
+			log.WithFields(log.Fields{
+				"caller": "session",
+				"error":  err,
+			}).Warning("Failed to renew session")
+			sl.sessionID.Store((*string)(nil))
+			sl.publish(SessionEvent{Type: SessionRenewalFailed, SessionID: sessionID, Err: err})
+		}
+	}()
+}
+
+func (sl *SessionLifecycle) cancelRenewal(eventType SessionEventType, sessionID string, err error) {
+	sl.cancelMu.Lock()
+	cancel := sl.renewCancel
+	sl.renewCancel = nil
+	sl.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
+		sl.publish(SessionEvent{Type: eventType, SessionID: sessionID, Err: err})
+	}
+}
+
+func (sl *SessionLifecycle) publish(event SessionEvent) {
+	select {
+	case sl.events <- event:
+	default:
+	}
+}

--- a/internal/ballot/session_lifecycle_test.go
+++ b/internal/ballot/session_lifecycle_test.go
@@ -1,0 +1,120 @@
+package ballot
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionLifecycle(t *testing.T) {
+	runtimeConfig := RuntimeConfig{
+		Name:          "test_service",
+		ID:            "test_service_id",
+		Key:           "election/test/leader",
+		ServiceChecks: []string{"service:test_service_id"},
+		TTL:           10 * time.Second,
+		LockDelay:     3 * time.Second,
+	}
+
+	t.Run("creates session with checks and timing", func(t *testing.T) {
+		var sessionID atomic.Value
+		mockSession := new(MockSession)
+		mockSession.On("Create", mock.MatchedBy(func(entry *api.SessionEntry) bool {
+			return entry.Behavior == "delete" &&
+				assert.ObjectsAreEqual([]string{"service:test_service_id", "serfHealth"}, entry.Checks) &&
+				entry.TTL == "10s" &&
+				entry.LockDelay == 3*time.Second
+		}), (*api.WriteOptions)(nil)).Return("session-1", nil, nil)
+		mockSession.On("RenewPeriodic", "10s", "session-1", (*api.WriteOptions)(nil), mock.Anything).Return(nil)
+
+		lifecycle := NewSessionLifecycle(context.Background(), mockSession, &sessionID, runtimeConfig)
+		id, err := lifecycle.ActiveSession()
+
+		require.NoError(t, err)
+		assert.Equal(t, "session-1", id)
+		stored, ok := lifecycle.getSessionID()
+		require.True(t, ok)
+		require.NotNil(t, stored)
+		assert.Equal(t, "session-1", *stored)
+	})
+
+	t.Run("reuses valid session", func(t *testing.T) {
+		var sessionID atomic.Value
+		current := "session-1"
+		sessionID.Store(&current)
+		mockSession := new(MockSession)
+		mockSession.On("Info", current, (*api.QueryOptions)(nil)).Return(&api.SessionEntry{ID: current}, &api.QueryMeta{}, nil)
+
+		lifecycle := NewSessionLifecycle(context.Background(), mockSession, &sessionID, runtimeConfig)
+		id, err := lifecycle.ActiveSession()
+
+		require.NoError(t, err)
+		assert.Equal(t, current, id)
+		mockSession.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+	})
+
+	t.Run("replaces invalid session", func(t *testing.T) {
+		var sessionID atomic.Value
+		current := "session-1"
+		sessionID.Store(&current)
+		mockSession := new(MockSession)
+		mockSession.On("Info", current, (*api.QueryOptions)(nil)).Return((*api.SessionEntry)(nil), &api.QueryMeta{}, nil)
+		mockSession.On("Create", mock.Anything, (*api.WriteOptions)(nil)).Return("session-2", nil, nil)
+		mockSession.On("RenewPeriodic", "10s", "session-2", (*api.WriteOptions)(nil), mock.Anything).Return(nil)
+
+		lifecycle := NewSessionLifecycle(context.Background(), mockSession, &sessionID, runtimeConfig)
+		id, err := lifecycle.ActiveSession()
+
+		require.NoError(t, err)
+		assert.Equal(t, "session-2", id)
+	})
+
+	t.Run("renewal failure is observable", func(t *testing.T) {
+		var sessionID atomic.Value
+		renewErr := errors.New("renew failed")
+		mockSession := new(MockSession)
+		mockSession.On("Create", mock.Anything, (*api.WriteOptions)(nil)).Return("session-1", nil, nil)
+		mockSession.On("RenewPeriodic", "10s", "session-1", (*api.WriteOptions)(nil), mock.Anything).Return(renewErr)
+
+		lifecycle := NewSessionLifecycle(context.Background(), mockSession, &sessionID, runtimeConfig)
+		_, err := lifecycle.ActiveSession()
+		require.NoError(t, err)
+
+		select {
+		case event := <-lifecycle.Events():
+			if event.Type == SessionCreated {
+				event = <-lifecycle.Events()
+			}
+			assert.Equal(t, SessionRenewalFailed, event.Type)
+			assert.Equal(t, renewErr, event.Err)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for renewal failure")
+		}
+		stored, ok := lifecycle.getSessionID()
+		require.True(t, ok)
+		assert.Nil(t, stored)
+	})
+
+	t.Run("release destroys existing session", func(t *testing.T) {
+		var sessionID atomic.Value
+		current := "session-1"
+		sessionID.Store(&current)
+		mockSession := new(MockSession)
+		mockSession.On("Destroy", current, (*api.WriteOptions)(nil)).Return(&api.WriteMeta{}, nil)
+
+		lifecycle := NewSessionLifecycle(context.Background(), mockSession, &sessionID, runtimeConfig)
+		err := lifecycle.Release()
+
+		require.NoError(t, err)
+		stored, ok := lifecycle.getSessionID()
+		require.True(t, ok)
+		assert.Nil(t, stored)
+	})
+}

--- a/internal/ballot/test_mocks_test.go
+++ b/internal/ballot/test_mocks_test.go
@@ -1,0 +1,182 @@
+package ballot
+
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockConsulClient struct {
+	mock.Mock
+}
+
+func (m *MockConsulClient) Agent() AgentInterface {
+	args := m.Called()
+	return args.Get(0).(AgentInterface)
+}
+
+func (m *MockConsulClient) Catalog() CatalogInterface {
+	args := m.Called()
+	return args.Get(0).(CatalogInterface)
+}
+
+func (m *MockConsulClient) Health() HealthInterface {
+	args := m.Called()
+	return args.Get(0).(HealthInterface)
+}
+
+func (m *MockConsulClient) KV() KVInterface {
+	args := m.Called()
+	return args.Get(0).(KVInterface)
+}
+
+func (m *MockConsulClient) Session() SessionInterface {
+	args := m.Called()
+	return args.Get(0).(SessionInterface)
+}
+
+type MockAgent struct {
+	mock.Mock
+}
+
+func (m *MockAgent) Service(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
+	args := m.Called(serviceID, q)
+	var service *api.AgentService
+	if args.Get(0) != nil {
+		service = args.Get(0).(*api.AgentService)
+	}
+	var meta *api.QueryMeta
+	if args.Get(1) != nil {
+		meta = args.Get(1).(*api.QueryMeta)
+	}
+	return service, meta, args.Error(2)
+}
+
+func (m *MockAgent) ServiceRegister(service *api.AgentServiceRegistration) error {
+	args := m.Called(service)
+	return args.Error(0)
+}
+
+func (m *MockAgent) ServiceDeregister(serviceID string) error {
+	args := m.Called(serviceID)
+	return args.Error(0)
+}
+
+type MockCatalog struct {
+	mock.Mock
+}
+
+func (m *MockCatalog) Service(serviceName, tag string, q *api.QueryOptions) ([]*api.CatalogService, *api.QueryMeta, error) {
+	args := m.Called(serviceName, tag, q)
+	var services []*api.CatalogService
+	if args.Get(0) != nil {
+		services = args.Get(0).([]*api.CatalogService)
+	}
+	var meta *api.QueryMeta
+	if args.Get(1) != nil {
+		meta = args.Get(1).(*api.QueryMeta)
+	}
+	return services, meta, args.Error(2)
+}
+
+func (m *MockCatalog) Register(reg *api.CatalogRegistration, w *api.WriteOptions) (*api.WriteMeta, error) {
+	args := m.Called(reg, w)
+	var meta *api.WriteMeta
+	if args.Get(0) != nil {
+		meta = args.Get(0).(*api.WriteMeta)
+	}
+	return meta, args.Error(1)
+}
+
+func (m *MockCatalog) Deregister(dereg *api.CatalogDeregistration, w *api.WriteOptions) (*api.WriteMeta, error) {
+	args := m.Called(dereg, w)
+	var meta *api.WriteMeta
+	if args.Get(0) != nil {
+		meta = args.Get(0).(*api.WriteMeta)
+	}
+	return meta, args.Error(1)
+}
+
+type MockSession struct {
+	mock.Mock
+}
+
+func (m *MockSession) Create(se *api.SessionEntry, q *api.WriteOptions) (string, *api.WriteMeta, error) {
+	args := m.Called(se, q)
+	sessionID := args.String(0)
+	var meta *api.WriteMeta
+	if args.Get(1) != nil {
+		meta = args.Get(1).(*api.WriteMeta)
+	}
+	return sessionID, meta, args.Error(2)
+}
+
+func (m *MockSession) Destroy(sessionID string, q *api.WriteOptions) (*api.WriteMeta, error) {
+	args := m.Called(sessionID, q)
+	var meta *api.WriteMeta
+	if args.Get(0) != nil {
+		meta = args.Get(0).(*api.WriteMeta)
+	}
+	return meta, args.Error(1)
+}
+
+func (m *MockSession) Info(sessionID string, q *api.QueryOptions) (*api.SessionEntry, *api.QueryMeta, error) {
+	args := m.Called(sessionID, q)
+	var entry *api.SessionEntry
+	if args.Get(0) != nil {
+		entry = args.Get(0).(*api.SessionEntry)
+	}
+	var meta *api.QueryMeta
+	if args.Get(1) != nil {
+		meta = args.Get(1).(*api.QueryMeta)
+	}
+	return entry, meta, args.Error(2)
+}
+
+func (m *MockSession) RenewPeriodic(initialTTL string, id string, q *api.WriteOptions, doneCh <-chan struct{}) error {
+	args := m.Called(initialTTL, id, q, doneCh)
+	return args.Error(0)
+}
+
+type MockHealth struct {
+	mock.Mock
+}
+
+func (m *MockHealth) Checks(service string, q *api.QueryOptions) (api.HealthChecks, *api.QueryMeta, error) {
+	args := m.Called(service, q)
+	var checks api.HealthChecks
+	switch value := args.Get(0).(type) {
+	case api.HealthChecks:
+		checks = value
+	case []*api.HealthCheck:
+		checks = api.HealthChecks(value)
+	}
+	meta, _ := args.Get(1).(*api.QueryMeta)
+	return checks, meta, args.Error(2)
+}
+
+type MockKV struct {
+	mock.Mock
+}
+
+func (m *MockKV) Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
+	args := m.Called(key, q)
+	pair, _ := args.Get(0).(*api.KVPair)
+	meta, _ := args.Get(1).(*api.QueryMeta)
+	return pair, meta, args.Error(2)
+}
+
+func (m *MockKV) Put(p *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error) {
+	args := m.Called(p, q)
+	meta, _ := args.Get(0).(*api.WriteMeta)
+	return meta, args.Error(1)
+}
+
+func (m *MockKV) Acquire(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
+	args := m.Called(p, q)
+	boolResult := args.Bool(0)
+	var meta *api.WriteMeta
+	if args.Get(1) != nil {
+		meta = args.Get(1).(*api.WriteMeta)
+	}
+	return boolResult, meta, args.Error(2)
+}


### PR DESCRIPTION
## Summary

This MR refactors the Ballot election runtime into smaller, testable components while preserving the existing user-facing configuration shape. The main behavior is still Consul-backed leader election with primary tag management and promote/demote hooks, but the responsibilities that were previously concentrated in `internal/ballot/ballot.go` are now split into focused runtime, Consul, session, election-step, and hook modules.

The branch contains one refactoring commit over `origin/main` and changes 16 files: 1,849 insertions and 1,140 deletions.

## Why This Change Was Made

The previous implementation kept configuration loading, Consul API calls, session creation and renewal, leader-state transitions, tag cleanup, hook execution, and most test mocks in one large `Ballot` implementation. That made the election behavior harder to test in isolation and forced many tests to depend on global Viper state.

This MR separates those responsibilities so each part can be validated independently:

- configuration is normalized before constructing `Ballot`
- Consul election operations are grouped behind a dedicated interaction layer
- one election pass now has explicit status results
- session lifecycle behavior is isolated and observable
- leadership hooks are modeled as explicit requests/results
- tests use shared mocks and targeted test files instead of one very large test file

## Main Changes

### Runtime Configuration

Added `internal/ballot/config.go` with explicit config types:

- `LoadedConfig`
- `LoadedConsulConfig`
- `LoadedElectionConfig`
- `LoadedServiceConfig`
- `RuntimeConfig`

`RuntimeConfigFor` now converts loaded config into runtime config, applies defaults, validates required fields, and parses duration strings.

Preserved defaults:

- `DefaultSessionTTL = 10s`
- `DefaultLockDelay = 3s`

Validation now happens before `Ballot` is constructed, including missing service IDs, missing election keys, missing names, invalid TTL values, and invalid lock delay values.

### CLI Configuration Adapter

Added `cmd/config_adapter.go` so the CLI can still read from Viper while `Ballot` itself no longer depends on Viper.

`cmd/run.go` now:

- reads each enabled service name from `election.enabled`
- builds a `ballot.RuntimeConfig` with `runtimeConfigFromViper`
- passes that config into `ballot.New(ctx, cfg)`
- returns a clearer error when configuration loading fails for a service

This keeps the same config file shape while removing global config reads from the core election package.

### Ballot Constructor Refactor

Changed `ballot.New` from:

```go
New(ctx context.Context, name string)
```

to:

```go
New(ctx context.Context, cfg RuntimeConfig)
```

The constructor now receives already-normalized runtime configuration, validates it, creates the Consul API client, stores the runtime values on `Ballot`, and initializes leadership hooks.

This makes tests and integrations easier because they can construct `RuntimeConfig` directly instead of mutating Viper globals.

### Consul Election Interaction

Added `internal/ballot/consul_interaction.go` to centralize Consul-specific election behavior in `ConsulElectionInteraction`.

It now owns:

- local service lookup
- health state evaluation for the configured service instance
- KV lock acquisition
- KV lock payload reads
- adding or removing the primary tag on the local service
- cleanup of stale primary tags from other service instances
- conversion helpers for Consul service registration structs

`Ballot` now delegates these operations through `interaction()` instead of implementing all Consul calls directly.

### Election Step Result Model

Added `internal/ballot/election_step.go`.

One election pass is now represented by `ElectionStep.Run()`, which returns an `ElectionStepResult` containing:

- `Status`
- `Err`
- `Leader`

The status values identify where the election step ended:

- `leader`
- `follower`
- `critical_health`
- `service_failure`
- `session_failure`
- `lock_failure`
- `cleanup_failure`
- `payload_failure`

`Ballot.election()` still returns an error for the existing caller flow, but the new result object gives tests and future callers better visibility into what happened during an election pass.

### Session Lifecycle

Added `internal/ballot/session_lifecycle.go`.

`SessionLifecycle` now handles:

- reusing a valid existing session
- replacing an invalid cached session
- creating a new Consul session with configured service checks plus `serfHealth`
- starting periodic session renewal
- cancelling renewal when sessions are replaced or released
- clearing local session state on renewal failure
- publishing session events
- destroying sessions on release

The session events include:

- `created`
- `renewal_failed`
- `cancelled`
- `released`

This replaces the previous inline renewal handling inside `Ballot.session()`.

### Leadership Hooks

Added `internal/ballot/hooks.go`.

Leadership hook execution now uses explicit request/result types:

- `HookRequest`
- `HookResult`
- `LeadershipHooks`

Hooks still receive the same environment values:

- `ADDRESS`
- `PORT`
- `SESSIONID`

The hook layer now records whether execution was skipped, failed, or timed out. Hook timeout calculation is centralized in `HookTimeout(ttl, lockDelay)`.

`Ballot` now also exposes hook results internally through `ObserveHookResult`, making hook behavior testable without relying only on logs.

### Ballot Orchestration Cleanup

`internal/ballot/ballot.go` is now much smaller and focused on orchestration.

It now delegates:

- config materialization to `RuntimeConfig`
- Consul reads/writes to `ConsulElectionInteraction`
- session creation and renewal to `SessionLifecycle`
- per-pass election execution to `ElectionStep`
- hook execution to `LeadershipHooks`

The `Ballot` type still retains the existing runtime fields, leader state, session ID, client, context, and executor so the existing internal behavior remains compatible with the rest of the package.

### Consul Interface Cleanup

The Consul wrapper structs were removed where they were no longer necessary. The real Consul API clients now satisfy the local interfaces directly.

`HealthInterface` was adjusted to use `api.HealthChecks`, matching the Consul API type used by the current implementation and shared test mocks.

### Test Refactor And Coverage

Added focused test files:

- `internal/ballot/config_test.go`
- `internal/ballot/election_step_test.go`
- `internal/ballot/hooks_test.go`
- `internal/ballot/session_lifecycle_test.go`
- `internal/ballot/test_mocks_test.go`

The large `internal/ballot/ballot_test.go` was reduced substantially, with behavior moved into more targeted tests.

New and updated tests cover:

- runtime config loading, defaults, validation, and invalid durations
- Viper-to-runtime-config adaptation in the CLI
- successful election transitions
- election failure status cases
- critical health handling
- session creation, reuse, replacement, renewal failure, and release
- hook command execution, environment variables, command failures, timeouts, and skipped hooks
- hook result observation
- shared Consul mocks for agent, catalog, health, KV, and session APIs

Integration tests were updated to construct `RuntimeConfig` directly instead of mutating global Viper state. Timing-sensitive cases now use `require.Eventually` instead of fixed sleeps where appropriate.

## Behavior Notes

- The external YAML configuration shape remains the same.
- CLI users still configure services under `election.services`.
- The global Consul token still works, and a service-level token still overrides it.
- Session TTL and lock delay defaults remain unchanged.
- Promote and demote hooks still receive `ADDRESS`, `PORT`, and `SESSIONID`.
- The election loop still runs an immediate election before entering the ticker loop.
- The election ticker interval still uses half the TTL, with a minimum interval of one second.

## Files Changed

- `cmd/config_adapter.go`: new Viper-to-runtime-config adapter
- `cmd/run.go`: constructs `RuntimeConfig` before creating `Ballot`
- `cmd/run_test.go`: updated CLI tests and added config adapter coverage
- `internal/ballot/config.go`: new loaded/runtime config model and validation
- `internal/ballot/consul_interaction.go`: new Consul election interaction layer
- `internal/ballot/election_step.go`: new explicit election-step result model
- `internal/ballot/hooks.go`: new leadership hook executor and result model
- `internal/ballot/session_lifecycle.go`: new session lifecycle manager
- `internal/ballot/ballot.go`: simplified orchestration that delegates to the new components
- `internal/ballot/ballot_test.go`: reduced and updated after moving targeted tests out
- `internal/ballot/ballot_integration_test.go`: updated to use `RuntimeConfig` directly
- `internal/ballot/config_test.go`: new config tests
- `internal/ballot/election_step_test.go`: new election-step tests
- `internal/ballot/hooks_test.go`: new hook tests
- `internal/ballot/session_lifecycle_test.go`: new session lifecycle tests
- `internal/ballot/test_mocks_test.go`: shared test mocks

## Validation

Local test suite passes:

```bash
rtk go test ./...
```

Result:

```text
Go test: 141 passed in 3 packages
```
